### PR TITLE
various improvements

### DIFF
--- a/accel/kvm/kvm-all.c
+++ b/accel/kvm/kvm-all.c
@@ -2692,12 +2692,13 @@ int kvm_cpu_exec(CPUState *cpu)
 #define CONFIG_UNKNOWN_ERROR_IS_PANIC
 #ifndef CONFIG_UNKNOWN_ERROR_IS_PANIC
 			fprintf(stderr, "Unknown exit code (%d) => ABORT\n", run->exit_reason);
-            assert(false);
 			ret = kvm_arch_handle_exit(cpu, run);
+            assert(ret == 0);
 #else
             debug_fprintf("kvm_arch_handle_exit(%d) => panic\n", run->exit_reason);
-			handle_hypercall_kafl_panic(run, cpu, (uint64_t)run->hypercall.args[0]);
-            ret = 0;
+			ret = kvm_arch_handle_exit(cpu, run);
+			if (ret != 0)
+				handle_hypercall_kafl_panic(run, cpu, (uint64_t)run->hypercall.args[0]);
 #endif
 #endif
             ret = kvm_arch_handle_exit(cpu, run);

--- a/compile_qemu_nyx.sh
+++ b/compile_qemu_nyx.sh
@@ -45,7 +45,8 @@ compile_libraries (){
 
   echo "[!] compiling libxdc..."
   cd libxdc
-  CFLAGS="-I../capstone_v4/include/" V=1 make libxdc.a
+  git checkout 641de7539e99f7faf5c8e8f1c8a4b37a9df52a5f
+  sudo make install
   cd ..
   echo "[!] libxdc is ready!"
 }

--- a/hw/i386/pc_q35.c
+++ b/hw/i386/pc_q35.c
@@ -533,3 +533,20 @@ static void pc_q35_2_4_machine_options(MachineClass *m)
 
 DEFINE_Q35_MACHINE(v2_4, "pc-q35-2.4", NULL,
                    pc_q35_2_4_machine_options);
+
+#ifdef QEMU_NYX
+static void pc_kAFL64_vmx_v1_0_machine_options(MachineClass *m)
+{
+    pc_q35_4_2_machine_options(m);
+    m->alias = "kAFL64";
+    //m->is_default = 1;
+    m->desc = "kAFL64 PC (Q35 + ICH9, 2009)";
+}
+
+static void kAFL64_init(MachineState *machine)
+{
+    pc_q35_init(machine);
+}
+
+DEFINE_PC_MACHINE(v1, "kAFL64-Q35", kAFL64_init, pc_kAFL64_vmx_v1_0_machine_options);
+#endif

--- a/hw/isa/lpc_ich9.c
+++ b/hw/isa/lpc_ich9.c
@@ -479,6 +479,7 @@ static void ich9_lpc_rcba_update(ICH9LPCState *lpc, uint32_t rcba_old)
     if (rcba_old & ICH9_LPC_RCBA_EN) {
         memory_region_del_subregion(get_system_memory(), &lpc->rcrb_mem);
     }
+    // Nyx snapshot reload fails here if ICH9_LPC_RCBA_EN=1
     if (rcba & ICH9_LPC_RCBA_EN) {
         memory_region_add_subregion_overlap(get_system_memory(),
                                             rcba & ICH9_LPC_RCBA_BA_MASK,

--- a/hw/virtio/virtio.c
+++ b/hw/virtio/virtio.c
@@ -2807,7 +2807,9 @@ static int virtio_device_put(QEMUFile *f, void *opaque, size_t size,
 }
 
 /* A wrapper for use as a VMState .get function */
-static int virtio_device_get(QEMUFile *f, void *opaque, size_t size,
+int virtio_device_get(QEMUFile *f, void *opaque, size_t size,
+                             const VMStateField *field);
+int virtio_device_get(QEMUFile *f, void *opaque, size_t size,
                              const VMStateField *field)
 {
     VirtIODevice *vdev = VIRTIO_DEVICE(opaque);

--- a/include/hw/i386/ich9.h
+++ b/include/hw/i386/ich9.h
@@ -177,7 +177,12 @@ typedef struct ICH9LPCState {
 
 #define ICH9_LPC_RCBA                           0xf0
 #define ICH9_LPC_RCBA_BA_MASK                   Q35_MASK(32, 31, 14)
+#ifdef QEMU_NYX
+// Nyx snapshot restore fails on this
+#define ICH9_LPC_RCBA_EN                        0x0
+#else
 #define ICH9_LPC_RCBA_EN                        0x1
+#endif
 #define ICH9_LPC_RCBA_DEFAULT                   0x0
 
 #define ICH9_LPC_PIC_NUM_PINS                   16

--- a/nyx/Makefile.objs
+++ b/nyx/Makefile.objs
@@ -7,6 +7,7 @@ synchronization.o \
 page_cache.o \
 kvm_nested.o \
 debug.o \
+trace_dump.o \
 auxiliary_buffer.o \
 mmh3.o \
 nested_hypercalls.o \

--- a/nyx/auxiliary_buffer.c
+++ b/nyx/auxiliary_buffer.c
@@ -25,6 +25,7 @@ along with QEMU-PT.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdbool.h>
 #include "nyx/state/state.h"
 #include "nyx/debug.h"
+#include "nyx/trace_dump.h"
 
 /* experimental feature (currently broken)
  * enabled via trace mode
@@ -104,6 +105,7 @@ void check_auxiliary_config_buffer(auxilary_buffer_t* auxilary_buffer, auxilary_
         GET_GLOBAL_STATE()->pt_trace_mode_force = true;		  
 #endif
         redqueen_set_trace_mode();
+        pt_trace_dump_enable(true);
       }
     }
     else {
@@ -113,6 +115,7 @@ void check_auxiliary_config_buffer(auxilary_buffer_t* auxilary_buffer, auxilary_
         GET_GLOBAL_STATE()->pt_trace_mode_force = false;
 #endif
         redqueen_unset_trace_mode();
+        pt_trace_dump_enable(false);
       }
     }
 

--- a/nyx/auxiliary_buffer.c
+++ b/nyx/auxiliary_buffer.c
@@ -166,6 +166,10 @@ void set_crash_auxiliary_result_buffer(auxilary_buffer_t* auxilary_buffer){
   VOLATILE_WRITE_8(auxilary_buffer->result.exec_result_code, rc_crash);
 }
 
+void set_asan_auxiliary_result_buffer(auxilary_buffer_t* auxilary_buffer){
+  VOLATILE_WRITE_8(auxilary_buffer->result.exec_result_code, rc_sanitizer);
+}
+
 void set_timeout_auxiliary_result_buffer(auxilary_buffer_t* auxilary_buffer){
   VOLATILE_WRITE_8(auxilary_buffer->result.exec_result_code, rc_timeout);
 }

--- a/nyx/auxiliary_buffer.c
+++ b/nyx/auxiliary_buffer.c
@@ -104,6 +104,7 @@ void check_auxiliary_config_buffer(auxilary_buffer_t* auxilary_buffer, auxilary_
 #ifdef SUPPORT_COMPILE_TIME_REDQUEEN
         GET_GLOBAL_STATE()->pt_trace_mode_force = true;		  
 #endif
+		GET_GLOBAL_STATE()->trace_mode = true;
         redqueen_set_trace_mode();
         pt_trace_dump_enable(true);
       }
@@ -114,6 +115,7 @@ void check_auxiliary_config_buffer(auxilary_buffer_t* auxilary_buffer, auxilary_
 #ifdef SUPPORT_COMPILE_TIME_REDQUEEN
         GET_GLOBAL_STATE()->pt_trace_mode_force = false;
 #endif
+		GET_GLOBAL_STATE()->trace_mode = false;
         redqueen_unset_trace_mode();
         pt_trace_dump_enable(false);
       }

--- a/nyx/auxiliary_buffer.c
+++ b/nyx/auxiliary_buffer.c
@@ -103,7 +103,7 @@ void check_auxiliary_config_buffer(auxilary_buffer_t* auxilary_buffer, auxilary_
 #ifdef SUPPORT_COMPILE_TIME_REDQUEEN
         GET_GLOBAL_STATE()->pt_trace_mode_force = true;		  
 #endif
-        redqueen_set_trace_mode(GET_GLOBAL_STATE()->redqueen_state);
+        redqueen_set_trace_mode();
       }
     }
     else {
@@ -112,7 +112,7 @@ void check_auxiliary_config_buffer(auxilary_buffer_t* auxilary_buffer, auxilary_
 #ifdef SUPPORT_COMPILE_TIME_REDQUEEN
         GET_GLOBAL_STATE()->pt_trace_mode_force = false;
 #endif
-		    redqueen_unset_trace_mode(GET_GLOBAL_STATE()->redqueen_state);
+        redqueen_unset_trace_mode();
       }
     }
 

--- a/nyx/auxiliary_buffer.c
+++ b/nyx/auxiliary_buffer.c
@@ -229,7 +229,12 @@ void reset_page_not_found_result_buffer(auxilary_buffer_t* auxilary_buffer){
 }
 
 void set_success_auxiliary_result_buffer(auxilary_buffer_t* auxilary_buffer, uint8_t success){
-  VOLATILE_WRITE_8(auxilary_buffer->result.exec_result_code, rc_success);
+  //should refactor to let caller directly set the result codes
+  if (success == 2) {
+	  VOLATILE_WRITE_8(auxilary_buffer->result.exec_result_code, rc_starved);
+  } else {
+	  VOLATILE_WRITE_8(auxilary_buffer->result.exec_result_code, rc_success);
+  }
 }
 
 void set_payload_buffer_write_reason_auxiliary_buffer(auxilary_buffer_t* auxilary_buffer, char* msg, uint32_t len){

--- a/nyx/auxiliary_buffer.h
+++ b/nyx/auxiliary_buffer.h
@@ -45,6 +45,7 @@ enum nyx_result_codes {
   rc_input_buffer_write = 4,
   rc_aborted = 5,
   rc_sanitizer = 6, 
+  rc_starved = 7,
 };
 
 typedef struct auxilary_buffer_header_s{

--- a/nyx/auxiliary_buffer.h
+++ b/nyx/auxiliary_buffer.h
@@ -74,7 +74,7 @@ typedef struct auxilary_buffer_config_s{
 
   /* trigger to enable / disable different QEMU-PT modes */
   uint8_t redqueen_mode; 
-  uint8_t trace_mode; 
+  uint8_t trace_mode;  /* dump decoded edge transitions to file */
   uint8_t reload_mode;
 
   uint8_t verbose_level;

--- a/nyx/auxiliary_buffer.h
+++ b/nyx/auxiliary_buffer.h
@@ -44,6 +44,7 @@ enum nyx_result_codes {
   rc_timeout = 3,
   rc_input_buffer_write = 4,
   rc_aborted = 5,
+  rc_sanitizer = 6, 
 };
 
 typedef struct auxilary_buffer_header_s{
@@ -149,6 +150,7 @@ void init_auxiliary_buffer(auxilary_buffer_t* auxilary_buffer);
 void check_auxiliary_config_buffer(auxilary_buffer_t* auxilary_buffer, auxilary_buffer_config_t* shadow_config);
 
 void set_crash_auxiliary_result_buffer(auxilary_buffer_t* auxilary_buffer);
+void set_asan_auxiliary_result_buffer(auxilary_buffer_t* auxilary_buffer);
 void set_timeout_auxiliary_result_buffer(auxilary_buffer_t* auxilary_buffer);
 void set_reload_auxiliary_result_buffer(auxilary_buffer_t* auxilary_buffer);
 void set_pt_overflow_auxiliary_result_buffer(auxilary_buffer_t* auxilary_buffer);

--- a/nyx/file_helper.c
+++ b/nyx/file_helper.c
@@ -56,7 +56,6 @@ void parse_address_file(char* path, size_t* num_addrs, uint64_t** addrs){
 
 int re_fd = 0;
 int se_fd = 0;
-int trace_fd = 0;
 
 void write_re_result(char* buf){
   int unused __attribute__((unused));
@@ -65,20 +64,7 @@ void write_re_result(char* buf){
 	unused = write(re_fd, buf, strlen(buf));
 }
 
-void write_trace_result(redqueen_trace_t* trace_state){
-	//int fd;
-  int unused __attribute__((unused));
-	if (!trace_fd)
-		trace_fd = open(redqueen_workdir.pt_trace_results, O_WRONLY | O_CREAT | O_APPEND, S_IRWXU);
-  redqueen_trace_write_file(trace_state, trace_fd);
-  //unused = write(trace_fd, buf, strlen(buf));
-	//close(fd);
-}
-
-void fsync_all_traces(void){
-  if (!trace_fd){
-    fsync(trace_fd);
-  }
+void fsync_redqueen_files(void){
   if (!se_fd){
     fsync(se_fd);
   }
@@ -94,13 +80,6 @@ void write_se_result(char* buf){
 		se_fd = open(redqueen_workdir.symbolic_results, O_WRONLY | O_CREAT | O_APPEND, S_IRWXU);
 	unused = write(se_fd, buf, strlen(buf));
 	//close(fd);
-}
-
-void delete_trace_files(void){
-  int unused __attribute__((unused));
-	if (!trace_fd)
-		trace_fd = open(redqueen_workdir.pt_trace_results, O_WRONLY | O_CREAT | O_APPEND, S_IRWXU);
-	unused = ftruncate(trace_fd, 0);
 }
 
 void delete_redqueen_files(void){

--- a/nyx/file_helper.h
+++ b/nyx/file_helper.h
@@ -1,7 +1,8 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include "redqueen_trace.h"
+
+#pragma once
 
 //doesn't take ownership of path, num_addrs or addrs
 void parse_address_file(char* path, size_t* num_addrs, uint64_t** addrs);
@@ -12,14 +13,9 @@ void write_re_result(char* buf);
 //doesn't take ownership of buf
 void write_se_result(char* buf);
 
-//doesn't take ownership of buf
-void write_trace_result(redqueen_trace_t* trace_state);
-
 //doesn' take ownership of buf
 void write_debug_result(char* buf);
 
 void delete_redqueen_files(void);
 
-void delete_trace_files(void);
-
-void fsync_all_traces(void);
+void fsync_redqueen_files(void);

--- a/nyx/hypercall/configuration.c
+++ b/nyx/hypercall/configuration.c
@@ -24,6 +24,7 @@ void handle_hypercall_kafl_get_host_config(struct kvm_run *run, CPUState *cpu, u
 	config.bitmap_size = GET_GLOBAL_STATE()->shared_bitmap_size;
 	config.ijon_bitmap_size = GET_GLOBAL_STATE()->shared_ijon_bitmap_size;
 	config.payload_buffer_size = GET_GLOBAL_STATE()->shared_payload_buffer_size;
+	config.worker_id = GET_GLOBAL_STATE()->worker_id;
 
 	write_virtual_memory(vaddr, (uint8_t*)&config, sizeof(host_config_t), cpu);
 	GET_GLOBAL_STATE()->get_host_config_done = true;

--- a/nyx/hypercall/configuration.h
+++ b/nyx/hypercall/configuration.h
@@ -19,6 +19,7 @@ typedef struct host_config_s{
   uint32_t bitmap_size;
   uint32_t ijon_bitmap_size;
 	uint32_t payload_buffer_size;
+  uint32_t worker_id;
   /* more to come */
 } __attribute__((packed)) host_config_t;
 

--- a/nyx/hypercall/hypercall.c
+++ b/nyx/hypercall/hypercall.c
@@ -615,7 +615,7 @@ static void handle_hypercall_kafl_printf(struct kvm_run *run, CPUState *cpu, uin
 #ifdef DEBUG_HPRINTF
 	fprintf(stderr, "%s %s\n", __func__, hprintf_buffer);
 #endif
-	set_hprintf_auxiliary_buffer(GET_GLOBAL_STATE()->auxilary_buffer, hprintf_buffer, strnlen(hprintf_buffer, HPRINTF_SIZE)+1);
+	set_hprintf_auxiliary_buffer(GET_GLOBAL_STATE()->auxilary_buffer, hprintf_buffer, strnlen(hprintf_buffer, HPRINTF_SIZE));
 	synchronization_lock();
 }
 

--- a/nyx/hypercall/hypercall.c
+++ b/nyx/hypercall/hypercall.c
@@ -349,6 +349,13 @@ void handle_hypercall_kafl_release(struct kvm_run *run, CPUState *cpu, uint64_t 
 		if (init_state){
 			init_state = false;	
 		} else {
+			//printf(CORE_PREFIX, "Got STARVED notification (num=%llu)\n", run->hypercall.args[0]);
+			if (run->hypercall.args[0] > 0) {
+				GET_GLOBAL_STATE()->starved = 1;
+			} else {
+				GET_GLOBAL_STATE()->starved = 0;
+			}
+
 			synchronization_disable_pt(cpu);
 			release_print_once(cpu);
 		}

--- a/nyx/hypercall/hypercall.c
+++ b/nyx/hypercall/hypercall.c
@@ -435,14 +435,22 @@ static void handle_hypercall_kafl_submit_panic(struct kvm_run *run, CPUState *cp
 
 	if(hypercall_enabled){
 		QEMU_PT_PRINTF(CORE_PREFIX, "Panic address:\t%lx", hypercall_arg);
-		write_virtual_memory(hypercall_arg, (uint8_t*)PANIC_PAYLOAD, PAYLOAD_BUFFER_SIZE, cpu);
+		if (run->hypercall.longmode) {
+			write_virtual_memory(hypercall_arg, (uint8_t*)PANIC_PAYLOAD_64, PAYLOAD_BUFFER_SIZE, cpu);
+		} else {
+			write_virtual_memory(hypercall_arg, (uint8_t*)PANIC_PAYLOAD_32, PAYLOAD_BUFFER_SIZE, cpu);
+		}
 	}
 }
 
 static void handle_hypercall_kafl_submit_kasan(struct kvm_run *run, CPUState *cpu, uint64_t hypercall_arg){
 	if(hypercall_enabled){
 		QEMU_PT_PRINTF(CORE_PREFIX, "kASAN address:\t%lx", hypercall_arg);
-		write_virtual_memory(hypercall_arg, (uint8_t*)KASAN_PAYLOAD, PAYLOAD_BUFFER_SIZE, cpu);
+		if (run->hypercall.longmode){
+			write_virtual_memory(hypercall_arg, (uint8_t*)KASAN_PAYLOAD_64, PAYLOAD_BUFFER_SIZE, cpu);
+		} else {
+			write_virtual_memory(hypercall_arg, (uint8_t*)KASAN_PAYLOAD_32, PAYLOAD_BUFFER_SIZE, cpu);
+		}
 	}
 }
 

--- a/nyx/hypercall/hypercall.c
+++ b/nyx/hypercall/hypercall.c
@@ -463,7 +463,7 @@ static void handle_hypercall_kafl_submit_kasan(struct kvm_run *run, CPUState *cp
 
 //#define PANIC_DEBUG
 
-static void handle_hypercall_kafl_panic(struct kvm_run *run, CPUState *cpu, uint64_t hypercall_arg){
+void handle_hypercall_kafl_panic(struct kvm_run *run, CPUState *cpu, uint64_t hypercall_arg){
 	static char reason[1024];
 	if(hypercall_enabled){
 #ifdef PANIC_DEBUG

--- a/nyx/hypercall/hypercall.c
+++ b/nyx/hypercall/hypercall.c
@@ -714,19 +714,6 @@ void pt_set_disable_patches_pending(CPUState *cpu){
 	GET_GLOBAL_STATE()->patches_disable_pending = true;
 }
 
-void pt_enable_rqi_trace(CPUState *cpu){
-	if (GET_GLOBAL_STATE()->redqueen_state){
-		redqueen_set_trace_mode(GET_GLOBAL_STATE()->redqueen_state);
-	}
-}
-
-void pt_disable_rqi_trace(CPUState *cpu){
-	if (GET_GLOBAL_STATE()->redqueen_state){
-		redqueen_unset_trace_mode(GET_GLOBAL_STATE()->redqueen_state);
-		return;
-	}
-}
-
 static void handle_hypercall_kafl_dump_file(struct kvm_run *run, CPUState *cpu, uint64_t hypercall_arg)
 {
 	kafl_dump_file_t file_obj;

--- a/nyx/hypercall/hypercall.h
+++ b/nyx/hypercall/hypercall.h
@@ -114,8 +114,7 @@ void hypercall_reload(void);
 
 void handle_hypercall_kafl_acquire(struct kvm_run *run, CPUState *cpu, uint64_t hypercall_arg);
 void handle_hypercall_kafl_release(struct kvm_run *run, CPUState *cpu, uint64_t hypercall_arg);
-
-
+void handle_hypercall_kafl_panic(struct kvm_run *run, CPUState *cpu, uint64_t hypercall_arg);
 
 void handle_hypercall_kafl_page_dump_bp(struct kvm_run *run, CPUState *cpu, uint64_t hypercall_arg, uint64_t page);
 

--- a/nyx/hypercall/hypercall.h
+++ b/nyx/hypercall/hypercall.h
@@ -46,18 +46,40 @@ bool check_bitmap_byte(uint32_t value);
  * 0f 01 c1                vmcall
  * f4                      hlt
  */
-#define PANIC_PAYLOAD "\xFA\x48\xC7\xC0\x1F\x00\x00\x00\x48\xC7\xC3\x08\x00\x00\x00\x48\xC7\xC1\x00\x00\x00\x00\x0F\x01\xC1\xF4"
+#define PANIC_PAYLOAD_64 "\xFA\x48\xC7\xC0\x1F\x00\x00\x00\x48\xC7\xC3\x08\x00\x00\x00\x48\xC7\xC1\x00\x00\x00\x00\x0F\x01\xC1\xF4"
+
+/*
+ * Panic Notifier Payload (x86-32)
+ * fa                      cli
+ * b8 1f 00 00 00          mov    $0x1f,%eax
+ * bb 08 00 00 00          mov    $0x8,%ebx
+ * b9 00 00 00 00          mov    $0x0,%ecx
+ * 0f 01 c1                vmcall
+ * f4                      hlt
+ */
+#define PANIC_PAYLOAD_32 "\xFA\xB8\x1F\x00\x00\x00\xBB\x08\x00\x00\x00\xB9\x00\x00\x00\x00\x0F\x01\xC1\xF4"
 
 /*
  * KASAN Notifier Payload (x86-64)
  * fa                      cli
  * 48 c7 c0 1f 00 00 00    mov    rax,0x1f
- * 48 c7 c3 08 00 00 00    mov    rbx,0x9
+ * 48 c7 c3 09 00 00 00    mov    rbx,0x9
  * 48 c7 c1 00 00 00 00    mov    rcx,0x0
  * 0f 01 c1                vmcall
  * f4                      hlt
  */
-#define KASAN_PAYLOAD "\xFA\x48\xC7\xC0\x1F\x00\x00\x00\x48\xC7\xC3\x09\x00\x00\x00\x48\xC7\xC1\x00\x00\x00\x00\x0F\x01\xC1\xF4"
+#define KASAN_PAYLOAD_64 "\xFA\x48\xC7\xC0\x1F\x00\x00\x00\x48\xC7\xC3\x09\x00\x00\x00\x48\xC7\xC1\x00\x00\x00\x00\x0F\x01\xC1\xF4"
+
+/*
+ * KASAN Notifier Payload (x86-32)
+ * fa                      cli
+ * b8 1f 00 00 00          mov    $0x1f,%eax
+ * bb 09 00 00 00          mov    $0x9,%ebx
+ * b9 00 00 00 00          mov    $0x0,%ecx
+ * 0f 01 c1                vmcall
+ * f4                      hlt
+ */
+#define KASAN_PAYLOAD_32 "\xFA\xB8\x1F\x00\x00\x00\xBB\x09\x00\x00\x00\xB9\x00\x00\x00\x00\x0F\x01\xC1\xF4"
 
 /*
  * printk Notifier Payload (x86-64)

--- a/nyx/hypercall/hypercall.h
+++ b/nyx/hypercall/hypercall.h
@@ -130,8 +130,6 @@ void pt_enable_rqo(CPUState *cpu);
 void pt_disable_rqo(CPUState *cpu);
 void pt_enable_rqi(CPUState *cpu);
 void pt_disable_rqi(CPUState *cpu);
-void pt_enable_rqi_trace(CPUState *cpu);
-void pt_disable_rqi_trace(CPUState *cpu);
 void pt_set_redqueen_instrumentation_mode(CPUState *cpu, int redqueen_instruction_mode);
 void pt_set_redqueen_update_blacklist(CPUState *cpu, bool newval);
 void pt_set_enable_patches_pending(CPUState *cpu);

--- a/nyx/interface.c
+++ b/nyx/interface.c
@@ -374,6 +374,7 @@ static void nyx_realize(DeviceState *dev, Error **errp){
 	if(s->cow_primary_size){
 		set_global_cow_cache_primary_size(s->cow_primary_size);
 	}
+	GET_GLOBAL_STATE()->worker_id = s->worker_id;
 
 	if (!s->workdir || !verify_workdir_state(s, errp)){
 		fprintf(stderr, "[QEMU-Nyx] Error:  work dir...\n");

--- a/nyx/interface.c
+++ b/nyx/interface.c
@@ -90,6 +90,7 @@ typedef struct nyx_interface_state {
 	uint32_t input_buffer_size;
 
 	bool dump_pt_trace;
+	bool edge_cb_trace;
 
 	bool redqueen;
 	
@@ -283,6 +284,10 @@ static bool verify_workdir_state(nyx_interface_state *s, Error **errp){
 	free(tmp);
   }
 
+  if(s->edge_cb_trace){
+	redqueen_trace_init();
+  }
+
 
 	assert(asprintf(&tmp, "%s/aux_buffer_%d", workdir, id) != -1);
 	/*
@@ -427,6 +432,7 @@ static Property nyx_interface_properties[] = {
 	DEFINE_PROP_UINT32("bitmap_size", nyx_interface_state, bitmap_size, DEFAULT_NYX_BITMAP_SIZE),
 	DEFINE_PROP_UINT32("input_buffer_size", nyx_interface_state, input_buffer_size, DEFAULT_NYX_BITMAP_SIZE),
 	DEFINE_PROP_BOOL("dump_pt_trace", nyx_interface_state, dump_pt_trace, false),
+	DEFINE_PROP_BOOL("edge_cb_trace", nyx_interface_state, edge_cb_trace, false),
 
 
 	DEFINE_PROP_END_OF_LIST(),

--- a/nyx/interface.c
+++ b/nyx/interface.c
@@ -277,9 +277,9 @@ static bool verify_workdir_state(nyx_interface_state *s, Error **errp){
 	init_redqueen_state();
 
   if(s->dump_pt_trace){
-	  assert(asprintf(&tmp, "%s/pt_trace_dump_%d", workdir, id) != -1);
-    	pt_open_pt_trace_file(tmp);
-    	free(tmp);
+	assert(asprintf(&tmp, "%s/pt_trace_dump_%d", workdir, id) != -1);
+	pt_trace_dump_enable(tmp);
+	free(tmp);
   }
 
 

--- a/nyx/interface.c
+++ b/nyx/interface.c
@@ -260,30 +260,6 @@ static bool verify_workdir_state(nyx_interface_state *s, Error **errp){
 	}
 	free(tmp);
 
-	assert(asprintf(&tmp, "%s/page_cache.lock", workdir) != -1);
-	if (!file_exits(tmp)){
-		fprintf(stderr, "%s does not exist...", tmp);
-		free(tmp);
-		return false;
-	}
-	free(tmp);
-
-	assert(asprintf(&tmp, "%s/page_cache.addr", workdir) != -1);
-	if (!file_exits(tmp)){
-		fprintf(stderr, "%s does not exist...\n", tmp);
-		free(tmp);
-		return false;
-	}
-	free(tmp);
-
-	assert(asprintf(&tmp, "%s/page_cache.dump", workdir) != -1);
-	if (!file_exits(tmp)){
-		fprintf(stderr,  "%s does not exist...\n", tmp);
-		free(tmp);
-		return false;
-	}
-	free(tmp);
-
 	assert(asprintf(&tmp, "%s/page_cache", workdir) != -1);
 	init_page_cache(tmp);
 

--- a/nyx/interface.c
+++ b/nyx/interface.c
@@ -51,6 +51,7 @@ along with QEMU-PT.  If not, see <http://www.gnu.org/licenses/>.
 #include "nyx/state/state.h"
 #include "nyx/sharedir.h"
 #include "nyx/helpers.h"
+#include "nyx/trace_dump.h"
 
 #include <time.h>
 
@@ -278,7 +279,7 @@ static bool verify_workdir_state(nyx_interface_state *s, Error **errp){
 
   if(s->dump_pt_trace){
 	assert(asprintf(&tmp, "%s/pt_trace_dump_%d", workdir, id) != -1);
-	pt_trace_dump_enable(tmp);
+	pt_trace_dump_init(tmp);
 	free(tmp);
   }
 

--- a/nyx/memory_access.c
+++ b/nyx/memory_access.c
@@ -216,8 +216,14 @@ bool remap_slot(uint64_t addr, uint32_t slot, CPUState *cpu, int fd, uint64_t sh
     QLIST_FOREACH_RCU(block, &ram_list.blocks, next) {
         if(!memcmp(block->idstr, "pc.ram", 6)){
             /* TODO: put assert calls here */ 
-            munmap((void*)(((uint64_t)block->host) + phys_addr), x86_64_PAGE_SIZE);
-            mmap((void*)(((uint64_t)block->host) + phys_addr), 0x1000, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, fd, (i*x86_64_PAGE_SIZE));
+            if (munmap((void*)(((uint64_t)block->host) + phys_addr), x86_64_PAGE_SIZE) == -1) {
+				fprintf(stderr, "%s: munmap failed!\n", __func__);
+				assert(false);
+			}
+            if (mmap((void*)(((uint64_t)block->host) + phys_addr), 0x1000, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, fd, (i*x86_64_PAGE_SIZE)) == MAP_FAILED) {
+				fprintf(stderr, "%s: mmap failed!\n", __func__);
+				assert(false);
+			}
 
             //printf("MMUNMAP: %d\n", munmap((void*)(((uint64_t)block->host) + phys_addr), x86_64_PAGE_SIZE));
             //printf("MMAP: %p\n", mmap((void*)(((uint64_t)block->host) + phys_addr), 0x1000, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, fd, (i*x86_64_PAGE_SIZE)));
@@ -286,6 +292,7 @@ void resize_shared_memory(uint32_t new_size, uint32_t* shm_size, void** shm_ptr,
 
 bool remap_payload_buffer(uint64_t virt_guest_addr, CPUState *cpu){    
     assert(GET_GLOBAL_STATE()->shared_payload_buffer_fd && GET_GLOBAL_STATE()->shared_payload_buffer_size);
+    assert(GET_GLOBAL_STATE()->shared_payload_buffer_size % x86_64_PAGE_SIZE == 0);
     RAMBlock *block;
     refresh_kvm_non_dirty(cpu);
 

--- a/nyx/page_cache.c
+++ b/nyx/page_cache.c
@@ -359,12 +359,12 @@ page_cache_t* page_cache_new(const char* cache_file, uint8_t disassembler_word_w
 
 
 	self->lookup = kh_init(PC_CACHE);
-	self->fd_page_file = open(tmp1, O_CLOEXEC | O_RDWR, S_IRWXU);
-	self->fd_address_file = open(tmp2, O_CLOEXEC | O_RDWR, S_IRWXU);
+	self->fd_page_file = open(tmp1, O_CLOEXEC | O_CREAT | O_RDWR, 0644);
+	self->fd_address_file = open(tmp2, O_CLOEXEC | O_CREAT | O_RDWR, 0644);
 
 #ifndef STANDALONE_DECODER
 	self->cpu = cpu;
-	self->fd_lock = open(tmp3, O_CLOEXEC);
+	self->fd_lock = open(tmp3, O_CLOEXEC | O_CREAT, 0644);
 	assert(self->fd_lock > 0);
 #else
 	if(self->fd_page_file == -1 || self->fd_address_file == -1){

--- a/nyx/page_cache.c
+++ b/nyx/page_cache.c
@@ -381,7 +381,11 @@ page_cache_t* page_cache_new(const char* cache_file, uint8_t disassembler_word_w
 	self->last_page = 0xFFFFFFFFFFFFFFFF;
 	self->last_addr = 0xFFFFFFFFFFFFFFFF;
 
+#ifndef STANDALONE_DECODER
 	QEMU_PT_PRINTF(PAGE_CACHE_PREFIX, "%s (%s - %s)", __func__, tmp1, tmp2);
+#else
+	QEMU_PT_PRINTF(PAGE_CACHE_PREFIX, "%s (%s - %s) WORD_WIDTH: %d", __func__, tmp1, tmp2, disassembler_word_width);
+#endif
 
 	free(tmp3);
 	free(tmp2);

--- a/nyx/page_cache.c
+++ b/nyx/page_cache.c
@@ -25,6 +25,9 @@
 
 #define UNMAPPED_PAGE 0xFFFFFFFFFFFFFFFFULL
 
+static void page_cache_unlock(page_cache_t* self);
+static void page_cache_lock(page_cache_t* self);
+
 #ifndef STANDALONE_DECODER
 static bool reload_addresses(page_cache_t* self){
 #else
@@ -39,6 +42,8 @@ bool reload_addresses(page_cache_t* self){
 
 	if(self_offset != self->num_pages*PAGE_CACHE_ADDR_LINE_SIZE){
 		//fprintf(stderr, "Reloading files ...\n");
+
+		page_cache_lock(self); // don't read while someone else is writing?
 
 		lseek(self->fd_address_file, self->num_pages*PAGE_CACHE_ADDR_LINE_SIZE, SEEK_SET);
 		offset = self->num_pages;
@@ -79,6 +84,8 @@ bool reload_addresses(page_cache_t* self){
 		munmap(self->page_data, self->num_pages*PAGE_SIZE);
 		self->num_pages = self_offset/PAGE_CACHE_ADDR_LINE_SIZE;
 		self->page_data = mmap(NULL, (self->num_pages)*PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, self->fd_page_file, 0);
+				
+		page_cache_unlock(self);
 
 		return true;
 	}

--- a/nyx/pt.c
+++ b/nyx/pt.c
@@ -185,7 +185,7 @@ void pt_dump(CPUState *cpu, int bytes){
 					GET_GLOBAL_STATE()->decoder_page_fault_addr = libxdc_get_page_fault_addr(GET_GLOBAL_STATE()->decoder);
 					break;
 				case decoder_unkown_packet:
-					fprintf(stderr, "WARNING: libxdc_decode returned decoder_error\n");
+					fprintf(stderr, "WARNING: libxdc_decode returned unknown_packet\n");
 					break;
 				case decoder_error:
 					fprintf(stderr, "WARNING: libxdc_decode returned decoder_error\n");

--- a/nyx/pt.c
+++ b/nyx/pt.c
@@ -44,6 +44,7 @@ along with QEMU-PT.  If not, see <http://www.gnu.org/licenses/>.
 #include "nyx/state/state.h"
 #include <libxdc.h>
 #include "nyx/helpers.h"
+#include "nyx/trace_dump.h"
 
 #define PT_BUFFER_MMAP_ADDR 0x3ffff0000000
 
@@ -52,55 +53,6 @@ uint32_t last = 0;
 
 uint32_t alt_bitmap_size = 0;
 uint8_t* alt_bitmap = NULL;
-
-int pt_trace_dump_fd = 0;
-char *pt_trace_dump_filename;
-bool should_dump_pt_trace= false; /* dump PT trace as returned from HW */
-
-void pt_trace_dump_enable(char* filename)
-{
-	int test_fd;
-
-	printf("Enable pt trace dump at %s", filename);
-	pt_trace_dump_filename = filename;
-	should_dump_pt_trace = true;
-
-	test_fd = open(filename, O_CREAT|O_TRUNC|O_WRONLY, 0644);
-	if (test_fd < 0)
-		fprintf(stderr, "Error accessing pt_dump output path: %s", strerror(errno));
-	assert(test_fd >= 0);
-}
-
-static void pt_truncate_pt_dump_file(void) {
-	int fd;
-
-	if (!should_dump_pt_trace)
-		return;
-
-	fd = open(pt_trace_dump_filename, O_CREAT|O_TRUNC|O_WRONLY, 0644);
-	if (fd < 0) {
-		fprintf(stderr, "Error truncating pt_trace_dump: %s\n", strerror(errno));
-		assert(0);
-	}
-	close(fd);
-}
-
-static void pt_write_pt_dump_file(uint8_t *data, size_t bytes)
-{
-	int fd;
-
-	if (!should_dump_pt_trace)
-		return;
-
-	fd = open(pt_trace_dump_filename, O_APPEND|O_WRONLY, 0644);
-	//fd = open(pt_trace_dump_filename, O_CREAT|O_TRUNC|O_WRONLY, 0644);
-	if (fd < 0) {
-		fprintf(stderr, "Error writing pt_trace_dump: %s\n", strerror(errno));
-		assert(0);
-	}
-    assert(bytes == write(fd, data, bytes));
-	close(fd);
-}
 
 static void pt_set(CPUState *cpu, run_on_cpu_data arg){
 	asm volatile("" ::: "memory");

--- a/nyx/pt.c
+++ b/nyx/pt.c
@@ -163,7 +163,7 @@ void alt_bitmap_add(uint64_t from, uint64_t to)
 {
 	uint64_t transition_value;
 
-	if (GET_GLOBAL_STATE()->redqueen_state->trace_mode) {
+	if (GET_GLOBAL_STATE()->trace_mode) {
 		if(alt_bitmap) {
 			transition_value = mix_bits(to)^(mix_bits(from)>>1);
 			alt_bitmap[transition_value & (alt_bitmap_size-1)]++;
@@ -233,8 +233,8 @@ int pt_enable(CPUState *cpu, bool hmp_mode){
 	if(!fast_reload_set_bitmap(get_fast_reload_snapshot())){
 		coverage_bitmap_reset();
 	}
-	if (GET_GLOBAL_STATE()->redqueen_state->trace_mode) {
-		delete_trace_files();
+	if (GET_GLOBAL_STATE()->trace_mode) {
+		redqueen_trace_reset();
 		alt_bitmap_reset();
 	}
 	pt_truncate_pt_dump_file();

--- a/nyx/pt.c
+++ b/nyx/pt.c
@@ -58,7 +58,7 @@ bool should_dump_pt_trace= false; /* dump PT trace as returned from HW */
 
 void pt_open_pt_trace_file(char* filename){
   printf("using pt trace at %s",filename);
-  pt_trace_dump_fd = open(filename, O_WRONLY);
+  pt_trace_dump_fd = open(filename, O_CREAT|O_TRUNC|O_WRONLY, 0644);
   should_dump_pt_trace = true;
   assert(pt_trace_dump_fd >= 0);
 }

--- a/nyx/pt.h
+++ b/nyx/pt.h
@@ -27,6 +27,10 @@ void pt_init_decoder(CPUState *cpu);
 void pt_reset_bitmap(void);
 void pt_setup_bitmap(void* ptr);
 
+void alt_bitmap_reset(void);
+void alt_bitmap_init(void* ptr, uint32_t size);
+void alt_bitmap_add(uint64_t from, uint64_t to);
+
 int pt_enable(CPUState *cpu, bool hmp_mode);
 int pt_disable(CPUState *cpu, bool hmp_mode);
 int pt_enable_ip_filtering(CPUState *cpu, uint8_t addrn, bool redqueen, bool hmp_mode);
@@ -39,7 +43,6 @@ void pt_post_kvm_run(CPUState *cpu);
 
 void pt_handle_overflow(CPUState *cpu);
 void pt_dump(CPUState *cpu, int bytes);
-void pt_bitmap(uint64_t from, uint64_t to);
 
 void pt_open_pt_trace_file(char* filename);
 void pt_trucate_pt_trace_file(void);

--- a/nyx/pt.h
+++ b/nyx/pt.h
@@ -45,6 +45,5 @@ void pt_handle_overflow(CPUState *cpu);
 void pt_dump(CPUState *cpu, int bytes);
 
 void pt_trace_dump_enable(char* filename);
-void pt_write_pt_dump_file(uint8_t *data, size_t bytes);
 #endif
 

--- a/nyx/pt.h
+++ b/nyx/pt.h
@@ -44,6 +44,5 @@ void pt_post_kvm_run(CPUState *cpu);
 void pt_handle_overflow(CPUState *cpu);
 void pt_dump(CPUState *cpu, int bytes);
 
-void pt_trace_dump_enable(char* filename);
 #endif
 

--- a/nyx/pt.h
+++ b/nyx/pt.h
@@ -24,13 +24,6 @@ along with QEMU-PT.  If not, see <http://www.gnu.org/licenses/>.
 
 void pt_init_decoder(CPUState *cpu);
 
-void pt_reset_bitmap(void);
-void pt_setup_bitmap(void* ptr);
-
-void alt_bitmap_reset(void);
-void alt_bitmap_init(void* ptr, uint32_t size);
-void alt_bitmap_add(uint64_t from, uint64_t to);
-
 int pt_enable(CPUState *cpu, bool hmp_mode);
 int pt_disable(CPUState *cpu, bool hmp_mode);
 int pt_enable_ip_filtering(CPUState *cpu, uint8_t addrn, bool redqueen, bool hmp_mode);

--- a/nyx/pt.h
+++ b/nyx/pt.h
@@ -44,7 +44,7 @@ void pt_post_kvm_run(CPUState *cpu);
 void pt_handle_overflow(CPUState *cpu);
 void pt_dump(CPUState *cpu, int bytes);
 
-void pt_open_pt_trace_file(char* filename);
-void pt_trucate_pt_trace_file(void);
+void pt_trace_dump_enable(char* filename);
+void pt_write_pt_dump_file(uint8_t *data, size_t bytes);
 #endif
 

--- a/nyx/redqueen.c
+++ b/nyx/redqueen.c
@@ -250,7 +250,6 @@ static void redqueen_trace_disabled(redqueen_t* self){
 }
 
 void redqueen_set_trace_mode(redqueen_t* self){
-	delete_trace_files();
 	self->trace_mode = true;
   redqueen_trace_enabled(self);
 }

--- a/nyx/redqueen.c
+++ b/nyx/redqueen.c
@@ -49,7 +49,6 @@ redqueen_t* new_rq_state(CPUState *cpu,  page_cache_t* page_cache){
 
 	res->cpu = cpu;
 	res->intercept_mode = false;
-	res->trace_mode = false;
 	res->singlestep_enabled = false;
   	res->hooks_applied = 0;
   	res->page_cache = page_cache;
@@ -223,43 +222,6 @@ void redqueen_callback(void* opaque, disassembler_mode_t mode, uint64_t start_ad
     }
     cs_free(insn, 1);
   }
-}
-
-
-
-static void redqueen_trace_enabled(redqueen_t* self){
-	int unused __attribute__((unused));
-	if(self->trace_mode){
-
-    //libxdc_enable_tracing(GET_GLOBAL_STATE()->decoder);
-    libxdc_enable_tracing(GET_GLOBAL_STATE()->decoder);
-	  libxdc_register_edge_callback(GET_GLOBAL_STATE()->decoder, (void (*)(void*, disassembler_mode_t, uint64_t, uint64_t))&redqueen_trace_register_transition, self->trace_state);
-		//redqueen_trace_register_transition(self->trace_state, INIT_TRACE_IP, ip);
-    //last_ip = ip;
-	} 
-}
-
-static void redqueen_trace_disabled(redqueen_t* self){
-  int unused __attribute__((unused));
-	if(self->trace_mode){
-    libxdc_disable_tracing(GET_GLOBAL_STATE()->decoder);
-
-		//redqueen_trace_register_transition(self->trace_state, last_ip, ip);
-		//edqueen_trace_register_transition(self->trace_state, ip, INIT_TRACE_IP);
-	}
-}
-
-void redqueen_set_trace_mode(redqueen_t* self){
-	self->trace_mode = true;
-  redqueen_trace_enabled(self);
-}
-
-void redqueen_unset_trace_mode(redqueen_t* self){
-	//write_trace_result(self->trace_state);
-	//redqueen_trace_reset(self->trace_state);
-  redqueen_trace_disabled(self);
-
-	self->trace_mode = false;
 }
 
 void destroy_rq_state(redqueen_t* self){

--- a/nyx/redqueen.h
+++ b/nyx/redqueen.h
@@ -70,7 +70,6 @@ KHASH_MAP_INIT_INT64(RQ, uint32_t)
 typedef struct redqueen_s{
 	khash_t(RQ) *lookup;
 	bool intercept_mode;
-	bool trace_mode;
 	bool singlestep_enabled;
 	int hooks_applied;
 	CPUState *cpu;
@@ -108,10 +107,6 @@ void handel_se_hook(redqueen_t* self);
 void enable_rq_intercept_mode(redqueen_t* self);
 void disable_rq_intercept_mode(redqueen_t* self);
 
-
-void redqueen_register_transition(redqueen_t* self, uint64_t ip, uint64_t transition_val);
-void redqueen_set_trace_mode(redqueen_t* self);
-void redqueen_unset_trace_mode(redqueen_t* self);
 
 void set_se_instruction(redqueen_t* self, uint64_t addr);
 

--- a/nyx/redqueen_trace.c
+++ b/nyx/redqueen_trace.c
@@ -4,11 +4,14 @@
 #include <assert.h>
 #include "redqueen_trace.h"
 
+void alt_bitmap_add(uint64_t from, uint64_t to);
+
 /* write full trace of edge transitions rather than sorted list? */
 //#define KAFL_FULL_TRACES
 
 #ifdef KAFL_FULL_TRACES
 #include "redqueen.h"
+extern int trace_fd;
 #endif
 
 redqueen_trace_t* redqueen_trace_new(void){
@@ -35,6 +38,10 @@ void redqueen_trace_free(redqueen_trace_t* self){
 void redqueen_trace_register_transition(redqueen_trace_t* self, disassembler_mode_t mode, uint64_t from, uint64_t to){
 	khiter_t k;
 	int ret;
+	uint64_t exit_ip = 0xffffffffffffffff;
+
+	if (from != exit_ip && to != exit_ip)
+		alt_bitmap_add(from, to);
 #ifdef KAFL_FULL_TRACES
 	extern int trace_fd;
 	if (!trace_fd)

--- a/nyx/redqueen_trace.c
+++ b/nyx/redqueen_trace.c
@@ -4,6 +4,13 @@
 #include <assert.h>
 #include "redqueen_trace.h"
 
+/* write full trace of edge transitions rather than sorted list? */
+//#define KAFL_FULL_TRACES
+
+#ifdef KAFL_FULL_TRACES
+#include "redqueen.h"
+#endif
+
 redqueen_trace_t* redqueen_trace_new(void){
 	redqueen_trace_t* self = malloc(sizeof(redqueen_trace_t));
 	self->lookup = kh_init(RQ_TRACE);
@@ -28,6 +35,13 @@ void redqueen_trace_free(redqueen_trace_t* self){
 void redqueen_trace_register_transition(redqueen_trace_t* self, disassembler_mode_t mode, uint64_t from, uint64_t to){
 	khiter_t k;
 	int ret;
+#ifdef KAFL_FULL_TRACES
+	extern int trace_fd;
+	if (!trace_fd)
+		trace_fd = open(redqueen_workdir.pt_trace_results, O_WRONLY | O_CREAT | O_APPEND, S_IRWXU);
+	dprintf(trace_fd, "%lx,%lx\n", from, to);
+	return;
+#endif
 	uint128_t key = (((uint128_t)from)<<64) | ((uint128_t)to);
 	k = kh_get(RQ_TRACE, self->lookup, key); 
 	if(k != kh_end(self->lookup)){
@@ -42,6 +56,9 @@ void redqueen_trace_register_transition(redqueen_trace_t* self, disassembler_mod
 }	
 
 void redqueen_trace_write_file(redqueen_trace_t* self, int fd){
+#ifdef KAFL_FULL_TRACES
+	return;
+#endif
 	for(size_t i = 0; i < self->num_ordered_transitions; i++){
 		khiter_t k;
 		uint128_t key = self->ordered_transitions[i];

--- a/nyx/redqueen_trace.c
+++ b/nyx/redqueen_trace.c
@@ -2,17 +2,29 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <assert.h>
+
 #include "redqueen_trace.h"
+#include "redqueen.h"
+#include "state/state.h"
+
 
 void alt_bitmap_add(uint64_t from, uint64_t to);
 
 /* write full trace of edge transitions rather than sorted list? */
 //#define KAFL_FULL_TRACES
 
-#ifdef KAFL_FULL_TRACES
-#include "redqueen.h"
-extern int trace_fd;
-#endif
+int trace_fd = 0;
+
+static int reset_trace_fd(void) {
+	if (trace_fd)
+		close(trace_fd);
+	trace_fd = open(redqueen_workdir.pt_trace_results, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	if (trace_fd < 0) {
+		fprintf(stderr, "Failed to initiate trace output: %s\n", strerror(errno));
+		assert(0);
+	}
+	return trace_fd;
+}
 
 redqueen_trace_t* redqueen_trace_new(void){
 	redqueen_trace_t* self = malloc(sizeof(redqueen_trace_t));
@@ -23,7 +35,8 @@ redqueen_trace_t* redqueen_trace_new(void){
 	return self;
 }
 
-void redqueen_trace_reset(redqueen_trace_t* self){
+static void redqueen_state_reset(void){
+	redqueen_trace_t *self = GET_GLOBAL_STATE()->redqueen_state->trace_state;
 	kh_destroy(RQ_TRACE, self->lookup);
 	self->lookup = kh_init(RQ_TRACE);
 	self->num_ordered_transitions = 0;
@@ -43,9 +56,7 @@ void redqueen_trace_register_transition(redqueen_trace_t* self, disassembler_mod
 	if (from != exit_ip && to != exit_ip)
 		alt_bitmap_add(from, to);
 #ifdef KAFL_FULL_TRACES
-	extern int trace_fd;
-	if (!trace_fd)
-		trace_fd = open(redqueen_workdir.pt_trace_results, O_WRONLY | O_CREAT | O_APPEND, S_IRWXU);
+	assert(trace_fd >= 0);
 	dprintf(trace_fd, "%lx,%lx\n", from, to);
 	return;
 #endif
@@ -62,24 +73,51 @@ void redqueen_trace_register_transition(redqueen_trace_t* self, disassembler_mod
 	}
 }	
 
-void redqueen_trace_write_file(redqueen_trace_t* self, int fd){
+static void redqueen_trace_write(void){
 #ifdef KAFL_FULL_TRACES
 	return;
 #endif
+	redqueen_trace_t *self = GET_GLOBAL_STATE()->redqueen_state->trace_state;
+	assert(trace_fd >= 0);
 	for(size_t i = 0; i < self->num_ordered_transitions; i++){
 		khiter_t k;
 		uint128_t key = self->ordered_transitions[i];
 		k = kh_get(RQ_TRACE, self->lookup, key); 
 		assert(k != kh_end(self->lookup));
-		dprintf(fd, "%lx,%lx,%lx\n",  (uint64_t)(key>>64), (uint64_t)key, kh_value(self->lookup, k) );
+		dprintf(trace_fd, "%lx,%lx,%lx\n",  (uint64_t)(key>>64), (uint64_t)key, kh_value(self->lookup, k) );
 	}
 }
 
+void redqueen_trace_reset(void){
+	redqueen_state_reset();
+	reset_trace_fd();
+}
+
+void redqueen_trace_flush(void){
+	redqueen_trace_write();
+	if (trace_fd)
+		fsync(trace_fd);
+}
+
+void redqueen_set_trace_mode(void){
+	GET_GLOBAL_STATE()->trace_mode = true;
+	libxdc_enable_tracing(GET_GLOBAL_STATE()->decoder);
+	libxdc_register_edge_callback(GET_GLOBAL_STATE()->decoder,
+			(void (*)(void*, disassembler_mode_t, uint64_t, uint64_t))&redqueen_trace_register_transition,
+			GET_GLOBAL_STATE()->redqueen_state->trace_state);
+}
+
+void redqueen_unset_trace_mode(void){
+    libxdc_disable_tracing(GET_GLOBAL_STATE()->decoder);
+	GET_GLOBAL_STATE()->trace_mode = false;
+}
 
 #ifdef DEBUG_MAIN
 int main(int argc, char** argv){
 
 	redqueen_trace_t* rq_obj = redqueen_trace_new();
+
+	reset_trace_fd();
 
 	for (uint64_t j = 0; j < 0x5; j++){
 		redqueen_trace_register_transition(rq_obj, 0xBADF, 0xC0FFEE);
@@ -87,8 +125,8 @@ int main(int argc, char** argv){
 		for (uint64_t i = 0; i < 0x10000; i++){
 			redqueen_trace_register_transition(rq_obj, 0xBADBEEF, 0xC0FFEE);
 		}
-		redqueen_trace_write_file(rq_obj, STDOUT_FILENO);
-		redqueen_trace_reset(rq_obj);
+		redqueen_trace_write(rq_obj, STDOUT_FILENO);
+		redqueen_state_reset();
 	}
 
 	redqueen_trace_free(rq_obj);

--- a/nyx/redqueen_trace.h
+++ b/nyx/redqueen_trace.h
@@ -37,7 +37,11 @@ typedef struct redqueen_trace_s{
 } redqueen_trace_t;
 
 redqueen_trace_t* redqueen_trace_new(void);
-void redqueen_trace_reset(redqueen_trace_t* self);
 void redqueen_trace_free(redqueen_trace_t* self);
 void redqueen_trace_register_transition(redqueen_trace_t* self, disassembler_mode_t mode, uint64_t from, uint64_t to);
-void redqueen_trace_write_file(redqueen_trace_t* self, int fd);
+
+void redqueen_set_trace_mode(void);
+void redqueen_unset_trace_mode(void);
+
+void redqueen_trace_flush(void);
+void redqueen_trace_reset(void);

--- a/nyx/redqueen_trace.h
+++ b/nyx/redqueen_trace.h
@@ -43,6 +43,10 @@ typedef struct redqueen_trace_s{
 	uint128_t* ordered_transitions;
 } redqueen_trace_t;
 
+/* libxdc outputs no bitmap in trace mode */
+void alt_bitmap_reset(void);
+void alt_bitmap_init(void* ptr, uint32_t size);
+
 redqueen_trace_t* redqueen_trace_new(void);
 void redqueen_trace_free(redqueen_trace_t* self);
 void redqueen_trace_register_transition(redqueen_trace_t* self, disassembler_mode_t mode, uint64_t from, uint64_t to);

--- a/nyx/redqueen_trace.h
+++ b/nyx/redqueen_trace.h
@@ -1,3 +1,10 @@
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "qemu/osdep.h"
+
 #pragma once
 #include "khash.h"
 #include <libxdc.h>
@@ -40,6 +47,7 @@ redqueen_trace_t* redqueen_trace_new(void);
 void redqueen_trace_free(redqueen_trace_t* self);
 void redqueen_trace_register_transition(redqueen_trace_t* self, disassembler_mode_t mode, uint64_t from, uint64_t to);
 
+void redqueen_trace_init(void);
 void redqueen_set_trace_mode(void);
 void redqueen_unset_trace_mode(void);
 

--- a/nyx/sharedir.c
+++ b/nyx/sharedir.c
@@ -167,6 +167,7 @@ uint64_t sharedir_request_file(sharedir_t* self, const char* file, uint8_t* page
     }
   }
   else{
+	  fprintf(stderr, "WARNING: No such file in sharedir: %s\n", file);
     return 0xFFFFFFFFFFFFFFFFUL;
   }
 }

--- a/nyx/snapshot/devices/nyx_device_state.c
+++ b/nyx/snapshot/devices/nyx_device_state.c
@@ -376,6 +376,12 @@ nyx_device_state_t* nyx_device_state_init_from_snapshot(const char* snapshot_fol
     return self;
 }
 
+/*
+ * This is where QemuFile is created for later fast_snapshot creation
+ * we use fast_qemu_savevm_state() to create a regular snapshot to QEMUFile
+ * backed by RAM. state_reallocation_new() then uses this file to build an
+ * optimized sequence of snapshot restore operations.
+ */
 nyx_device_state_t* nyx_device_state_init(void){
 
     nyx_device_state_t* self = malloc(sizeof(nyx_device_state_t));

--- a/nyx/snapshot/devices/state_reallocation.c
+++ b/nyx/snapshot/devices/state_reallocation.c
@@ -283,13 +283,45 @@ static void add_post_fptr(state_reallocation_t* self, void* fptr, uint32_t versi
 extern void fast_get_pci_config_device(void* data, size_t size, void* opaque);
 void fast_get_pci_irq_state(void* data, size_t size, void* opaque);
 
+//void fast_virtio_device_get(void* data, size_t size, void* opaque);
+int virtio_device_get(QEMUFile *f, void *opaque, size_t size, const VMStateField *field);
+
+static int fast_loadvm_fclose(void *opaque){
+    return 0;
+}
+
+static ssize_t fast_loadvm_get_buffer(void *opaque, uint8_t *buf, int64_t pos, size_t size){
+	assert(pos < ((struct fast_savevm_opaque_t*)(opaque))->buflen);
+    memcpy(buf, (void*)(((struct fast_savevm_opaque_t*)(opaque))->buf + pos), size);
+    return size;
+}
+
+static const QEMUFileOps fast_loadvm_ops = {
+    .get_buffer     = (QEMUFileGetBufferFunc*)fast_loadvm_get_buffer,
+    .close          = (QEMUFileCloseFunc*)fast_loadvm_fclose
+};
+
+/* use opaque data to bootstrap virtio restore from QEMUFile */
+static void fast_virtio_device_get(void* data, size_t size, void* opaque)
+{
+    struct fast_savevm_opaque_t fast_loadvm_opaque = {
+		.buf = data,
+		.buflen = size,
+		.f = NULL,
+		.pos = 0,
+	};
+    QEMUFile* f = qemu_fopen_ops(&fast_loadvm_opaque, &fast_loadvm_ops);
+
+	virtio_device_get(f, opaque, size, NULL);
+}
+
 static void add_get(state_reallocation_t* self, void* fptr, void* opaque, size_t size, void* field, QEMUFile* f, const char* name){
     if(!self){
         return;
     }
 
     void (*handler)(void* , size_t, void*) = NULL;
-    void* data = NULL; 
+    uint8_t* data = NULL;
 
     if(!strcmp(name, "timer")){
         debug_fprintf(stderr, "SKPPING: %ld\n", size*-1);
@@ -315,13 +347,21 @@ static void add_get(state_reallocation_t* self, void* fptr, void* opaque, size_t
         data = malloc(sizeof(uint8_t)*size);
         qemu_get_buffer(f, (uint8_t*)data, size);
     }
-    
+    else if(!strcmp(name, "virtio")){
+        fprintf(stderr, "WARNING: ATTEMPTING FAST GET for %s\n", name);
+        qemu_file_skip(f, size * -1);
+        handler = fast_virtio_device_get;
+        data = malloc(sizeof(uint8_t)*size);
+        qemu_get_buffer(f, (uint8_t*)data, size);
+	}
     else{
         fprintf(stderr, "WARNING: NOT IMPLEMENTED FAST GET ROUTINE for %s\n", name);
         abort();
         return;
     }
 
+	// will be called by pre-/post-save or pre-post-load?
+	// will be processed by fdl_fast_reload()
     self->get_fptr[self->fast_state_get_fptr_pos] = handler;
     self->get_opaque[self->fast_state_get_fptr_pos] = opaque;
     self->get_size[self->fast_state_get_fptr_pos] = size;
@@ -481,19 +521,21 @@ static inline int get_handler(state_reallocation_t* self, QEMUFile* f, void* cur
         add_get(self, (void*) field->info->get, curr_elem, size, (void*) field, f, field->info->name);
     }
     else if(!strcmp(field->info->name, "pci config")){
-        //fprintf(stderr, "type: %s (size: %x)\n", field->info->name, size);
+        fprintf(stderr, "type: %s (size: %lx)\n", field->info->name, size);
         add_get(self, (void*) field->info->get, curr_elem, size, (void*) field, f, field->info->name);
     }
     else if(!strcmp(field->info->name, "pci irq state")){
-        //fprintf(stderr, "type: %s (size: %x)\n", field->info->name, size);
+        fprintf(stderr, "type: %s (size: %lx)\n", field->info->name, size);
         add_get(self, (void*) field->info->get, curr_elem, size, (void*) field, f, field->info->name);
     }
     else if(!strcmp(field->info->name, "virtio")){
-        fprintf(stderr, "type: %s (size: %lx)\n", field->info->name, size);
-        abort(); /* not yet implemented */ 
+        add_get(self, (void*) field->info->get, curr_elem, size, (void*) field, f, field->info->name);
+		//fprintf(stderr, "[QEMU-PT] %s: WARNING no handler for %s, type %s, size %lx!\n",
+		//	   	__func__, vmsd_name, field->info->name, size);
     }
     else{
-        fprintf(stderr, "FAIL field->info->name: %s\n", field->info->name);
+		fprintf(stderr, "[QEMU-PT] %s: WARNING no handler for %s, type %s, size %lx!\n",
+			   	__func__, vmsd_name, field->info->name, size);
         assert(0);
     }
 
@@ -918,6 +960,7 @@ state_reallocation_t* state_reallocation_new(QEMUFile *f){
     self->tmp_snapshot.enabled = false;
     self->tmp_snapshot.fast_state_size = 0;
 
+    // actually enumerate the devices here
     fdl_enumerate_global_states(self, f);
 
     self->tmp_snapshot.copy = malloc(sizeof(void*) * self->fast_state_pos);

--- a/nyx/snapshot/devices/state_reallocation.h
+++ b/nyx/snapshot/devices/state_reallocation.h
@@ -50,6 +50,7 @@ struct QEMUFile_tmp {
 struct fast_savevm_opaque_t{
     FILE* f;
     uint8_t* buf;
+    size_t buflen;
     uint64_t pos;
     void* output_buffer;
     uint32_t* output_buffer_size;

--- a/nyx/state/state.c
+++ b/nyx/state/state.c
@@ -91,6 +91,7 @@ void state_init_global(void){
     global_state.in_fuzzing_mode = false;
     global_state.in_reload_mode = true;
     global_state.starved = false;
+    global_state.trace_mode = false;
     global_state.shutdown_requested = false;
     global_state.cow_cache_full = false;
 

--- a/nyx/state/state.c
+++ b/nyx/state/state.c
@@ -89,6 +89,7 @@ void state_init_global(void){
 
     global_state.in_fuzzing_mode = false;
     global_state.in_reload_mode = true;
+    global_state.starved = false;
     global_state.shutdown_requested = false;
     global_state.cow_cache_full = false;
 

--- a/nyx/state/state.c
+++ b/nyx/state/state.c
@@ -45,6 +45,7 @@ void state_init_global(void){
     global_state.nyx_fdl = false;
 
     global_state.workdir_path = NULL;
+    global_state.worker_id = 0xffff;
 
     global_state.fast_reload_enabled = false;
     global_state.fast_reload_mode = false;

--- a/nyx/state/state.h
+++ b/nyx/state/state.h
@@ -131,6 +131,7 @@ typedef struct qemu_nyx_state_s{
 
     bool in_fuzzing_mode;
     bool in_reload_mode; 
+     bool starved;
 
     bool shutdown_requested;
     bool cow_cache_full;

--- a/nyx/state/state.h
+++ b/nyx/state/state.h
@@ -49,6 +49,7 @@ typedef struct qemu_nyx_state_s{
     bool nyx_fdl;
 
     char* workdir_path;
+    uint32_t worker_id;
 
     /* FAST VM RELOAD */
     bool fast_reload_enabled;

--- a/nyx/state/state.h
+++ b/nyx/state/state.h
@@ -132,7 +132,8 @@ typedef struct qemu_nyx_state_s{
 
     bool in_fuzzing_mode;
     bool in_reload_mode; 
-     bool starved;
+    bool starved;
+    bool trace_mode;
 
     bool shutdown_requested;
     bool cow_cache_full;

--- a/nyx/synchronization.c
+++ b/nyx/synchronization.c
@@ -277,12 +277,12 @@ void synchronization_lock(void){
 
 	//last_timeout = false;
 
-	if(unlikely(GET_GLOBAL_STATE()->in_redqueen_reload_mode || GET_GLOBAL_STATE()->redqueen_state->trace_mode)){
-		if(GET_GLOBAL_STATE()->redqueen_state->trace_mode){
-			write_trace_result(GET_GLOBAL_STATE()->redqueen_state->trace_state);
-			redqueen_trace_reset(GET_GLOBAL_STATE()->redqueen_state->trace_state);
-		}
-		fsync_all_traces();		
+	if(unlikely(GET_GLOBAL_STATE()->in_redqueen_reload_mode)) {
+			fsync_redqueen_files();		
+	}
+
+	if (unlikely(GET_GLOBAL_STATE()->trace_mode)) {
+		redqueen_trace_flush();
 	}
 
 	interface_send_char(NYX_INTERFACE_PING);

--- a/nyx/synchronization.c
+++ b/nyx/synchronization.c
@@ -291,7 +291,12 @@ void synchronization_lock(void){
 	pthread_mutex_unlock(&synchronization_lock_mutex);
 
 	check_auxiliary_config_buffer(GET_GLOBAL_STATE()->auxilary_buffer, &GET_GLOBAL_STATE()->shadow_config);
-	set_success_auxiliary_result_buffer(GET_GLOBAL_STATE()->auxilary_buffer, 1);
+
+	//set_success_auxiliary_result_buffer(GET_GLOBAL_STATE()->auxilary_buffer, 1);
+	if (GET_GLOBAL_STATE()->starved == true)
+		set_success_auxiliary_result_buffer(GET_GLOBAL_STATE()->auxilary_buffer, 2);
+	else
+		set_success_auxiliary_result_buffer(GET_GLOBAL_STATE()->auxilary_buffer, 1);
 
 	GET_GLOBAL_STATE()->pt_trace_size = 0;
 	/*

--- a/nyx/synchronization.c
+++ b/nyx/synchronization.c
@@ -335,6 +335,25 @@ void synchronization_lock_crash_found(void){
 	in_fuzzing_loop = false;
 }
 
+void synchronization_lock_asan_found(void){
+	if(!in_fuzzing_loop){
+		fprintf(stderr, "<%d-%ld>\t%s [NOT IN FUZZING LOOP]\n", getpid(), run_counter, __func__);
+		set_success_auxiliary_result_buffer(GET_GLOBAL_STATE()->auxilary_buffer, 0);
+	}
+
+	pt_disable(qemu_get_cpu(0), false);
+
+	handle_tmp_snapshot_state();
+
+	set_asan_auxiliary_result_buffer(GET_GLOBAL_STATE()->auxilary_buffer);
+	
+	perform_reload();
+
+	//synchronization_lock();
+
+	in_fuzzing_loop = false;
+}
+
 void synchronization_lock_timeout_found(void){		
 	
 	//fprintf(stderr, "<%d>\t%s\n", getpid(), __func__);

--- a/nyx/synchronization.h
+++ b/nyx/synchronization.h
@@ -37,6 +37,7 @@ void synchronization_lock_hprintf(void);
 
 void synchronization_lock(void);
 void synchronization_lock_crash_found(void);
+void synchronization_lock_asan_found(void);
 void synchronization_lock_timeout_found(void);
 void synchronization_lock_shutdown_detected(void);
 void synchronization_cow_full_detected(void);

--- a/nyx/trace_dump.c
+++ b/nyx/trace_dump.c
@@ -1,0 +1,66 @@
+#include <stdint.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <assert.h>
+
+#include "state/state.h"
+#include "trace_dump.h"
+
+/* dump PT trace as returned from HW */
+
+char *pt_trace_dump_filename;
+bool pt_dump_initialized = false;
+bool pt_dump_enabled = false;
+
+void pt_trace_dump_enable(bool enable){
+	if (pt_dump_initialized)
+		pt_dump_enabled = enable;
+}
+
+void pt_trace_dump_init(char* filename)
+{
+	int test_fd;
+
+	//fprintf(stderr, "Enable pt trace dump at %s", filename);
+	pt_dump_initialized = true;
+
+	test_fd = open(filename, O_CREAT|O_TRUNC|O_WRONLY, 0644);
+	if (test_fd < 0)
+		fprintf(stderr, "Error accessing pt_dump output path %s: %s", pt_trace_dump_filename, strerror(errno));
+	assert(test_fd >= 0);
+
+	pt_trace_dump_filename = strdup(filename);
+	assert(pt_trace_dump_filename);
+}
+
+void pt_truncate_pt_dump_file(void) {
+	int fd;
+
+	if (!pt_dump_enabled)
+		return;
+
+	fd = open(pt_trace_dump_filename, O_CREAT|O_TRUNC|O_WRONLY, 0644);
+	if (fd < 0) {
+		fprintf(stderr, "Error truncating %s: %s\n", pt_trace_dump_filename, strerror(errno));
+		assert(0);
+	}
+	close(fd);
+}
+
+void pt_write_pt_dump_file(uint8_t *data, size_t bytes)
+{
+	int fd;
+
+	if (!pt_dump_enabled)
+		return;
+
+	fd = open(pt_trace_dump_filename, O_APPEND|O_WRONLY, 0644);
+	//fd = open(pt_trace_dump_filename, O_CREAT|O_TRUNC|O_WRONLY, 0644);
+	if (fd < 0) {
+		fprintf(stderr, "Error writing pt_trace_dump to %s: %s\n", pt_trace_dump_filename, strerror(errno));
+		assert(0);
+	}
+    assert(bytes == write(fd, data, bytes));
+	close(fd);
+}
+

--- a/nyx/trace_dump.h
+++ b/nyx/trace_dump.h
@@ -1,0 +1,6 @@
+#pragma once
+
+void pt_trace_dump_init(char* filename);
+void pt_trace_dump_enable(bool enable);
+void pt_write_pt_dump_file(uint8_t *data, size_t bytes);
+void pt_truncate_pt_dump_file(void);


### PR DESCRIPTION
incompatible interface changes:
- new return code RC_SANITIZER (KASAN hypercall)
- new return code RC_STARVED (execution returned OK but needs longer fuzz input)
- new cmdline options 'dump_pt_trace' and 'edge_cb_trace' to select between new (faster) pt_dump trace mode and existing libxdc callback mode