### PR TITLE
compile.sh fixes

### DIFF
--- a/compile_qemu_nyx.sh
+++ b/compile_qemu_nyx.sh
@@ -43,7 +43,7 @@ compile_libraries()
   make -C capstone_v4 -j $(nproc)
 
   echo "[!] Compiling libxdc..."
-  CFLAGS="-I$PWD/capstone_v4/include/" make -C libxdc -j $(nproc)
+  LDFLAGS="-L$PWD/capstone_v4 -L$PWD/libxdc" CFLAGS="-I$PWD/capstone_v4/include/" make -C libxdc -j $(nproc)
 
   case $1 in
     "dynamic"|"debug")

--- a/compile_qemu_nyx.sh
+++ b/compile_qemu_nyx.sh
@@ -40,17 +40,17 @@ error()
 compile_libraries()
 {
   echo "[!] Compiling capstone4..."
-  make -C capstone_v4 -j $(nproc)
+  make -C $CAPSTONE_ROOT -j $(nproc)
 
   echo "[!] Compiling libxdc..."
-  LDFLAGS="-L$PWD/capstone_v4 -L$PWD/libxdc" CFLAGS="-I$PWD/capstone_v4/include/" make -C libxdc -j $(nproc)
+  LDFLAGS="-L$CAPSTONE_ROOT -L$LIBXDC_ROOT" CFLAGS="-I$CAPSTONE_ROOT/include/" make -C $LIBXDC_ROOT -j $(nproc)
 
   case $1 in
     "dynamic"|"debug")
       echo "[!] Installing capstone4..."
-      sudo make -C capstone_v4 install
+      sudo make -C $CAPSTONE_ROOT install
       echo "[!] Installing libxdc..."
-      sudo make -C libxdc install
+      sudo make -C $LIBXDC_ROOT install
       ;;
   esac
 }
@@ -61,8 +61,8 @@ configure_qemu()
 
   case $1 in
     "debug_static"|"static"|"lto")
-      export LIBS="-L$PWD/capstone_v4/ -L$PWD/libxdc/ $LIBS"
-      export QEMU_CFLAGS="-I$PWD/capstone_v4/include/ -I$PWD/libxdc/ $QEMU_CFLAGS"
+      export LIBS="-L$CAPSTONE_ROOT -L$LIBXDC_ROOT/ $LIBS"
+      export QEMU_CFLAGS="-I$CAPSTONE_ROOT/include/ -I$LIBXDC_ROOT/ $QEMU_CFLAGS"
       ;;
     *)
       error
@@ -102,9 +102,14 @@ if [ "$#" -ne 1 ] ; then
   error
 fi
 
-git submodule init
-git submodule update libxdc
-git submodule update capstone_v4
+if [ -z "$LIBXDC_ROOT" -o -z "$CAPSTONE_ROOT" ]; then
+	git submodule init
+	git submodule update libxdc
+	git submodule update capstone_v4
+	
+	LIBXDC_ROOT="$PWD/libxdc"
+	CAPSTONE_ROOT="$PWD/capstone_v4"
+fi
 
 make clean
 compile_libraries $1

--- a/compile_qemu_nyx.sh
+++ b/compile_qemu_nyx.sh
@@ -60,6 +60,16 @@ configure_qemu()
   QEMU_CONFIGURE="./configure --target-list=x86_64-softmmu --disable-gtk --disable-docs --enable-gtk --disable-werror --disable-capstone --disable-libssh --disable-tools"
 
   case $1 in
+    "debug_static"|"static"|"lto")
+      export LIBS="-L$PWD/capstone_v4/ -L$PWD/libxdc/ $LIBS"
+      export QEMU_CFLAGS="-I$PWD/capstone_v4/include/ -I$PWD/libxdc/ $QEMU_CFLAGS"
+      ;;
+    *)
+      error
+      ;;
+  esac
+
+  case $1 in
     "dynamic")
       $QEMU_CONFIGURE --enable-nyx
       ;;

--- a/configure
+++ b/configure
@@ -6105,8 +6105,7 @@ if test "$nyx" = "yes" ; then
   CFLAGS="-DNESTED_PATCH -Wno-error=maybe-uninitialized -DQEMU_NYX -g -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 $QEMU_CFLAGS"
 
   if test "$nyx_static" = "yes" ; then
-    LIBS="-L$PWD/capstone_v4/ -l:libcapstone.a -L$PWD/libxdc/ -l:libxdc.a -I$PWD/capstone_v4/include/ -I$PWD/libxdc/ $LIBS"
-    QEMU_INCLUDES=" -I$PWD/capstone_v4/include/ -I$PWD/libxdc/ $QEMU_INCLUDES"
+    LIBS="-l:libcapstone.a -l:libxdc.a $LIBS"
   else
     LIBS="-lcapstone -lxdc $LIBS"
   fi


### PR DESCRIPTION
Should be no impact on how libxdc/capstone/qemu are actually build.

Note that the check for existing libcapstone/libxdc install was removed.
I think we want to always overwrite (or abort with error to let user decide).