### PR TITLE
Page cache racing

### DIFF
--- a/nyx/interface.c
+++ b/nyx/interface.c
@@ -262,6 +262,30 @@ static bool verify_workdir_state(nyx_interface_state *s, Error **errp){
 	}
 	free(tmp);
 
+	assert(asprintf(&tmp, "%s/page_cache.lock", workdir) != -1);
+	if (!file_exits(tmp)){
+		fprintf(stderr, "%s does not exist...", tmp);
+		free(tmp);
+		return false;
+	}
+	free(tmp);
+
+	assert(asprintf(&tmp, "%s/page_cache.addr", workdir) != -1);
+	if (!file_exits(tmp)){
+		fprintf(stderr, "%s does not exist...\n", tmp);
+		free(tmp);
+		return false;
+	}
+	free(tmp);
+
+	assert(asprintf(&tmp, "%s/page_cache.dump", workdir) != -1);
+	if (!file_exits(tmp)){
+		fprintf(stderr,  "%s does not exist...\n", tmp);
+		free(tmp);
+		return false;
+	}
+	free(tmp);
+
 	assert(asprintf(&tmp, "%s/page_cache", workdir) != -1);
 	init_page_cache(tmp);
 

--- a/nyx/page_cache.c
+++ b/nyx/page_cache.c
@@ -25,9 +25,6 @@
 
 #define UNMAPPED_PAGE 0xFFFFFFFFFFFFFFFFULL
 
-static void page_cache_unlock(page_cache_t* self);
-static void page_cache_lock(page_cache_t* self);
-
 #ifndef STANDALONE_DECODER
 static bool reload_addresses(page_cache_t* self){
 #else
@@ -42,8 +39,6 @@ bool reload_addresses(page_cache_t* self){
 
 	if(self_offset != self->num_pages*PAGE_CACHE_ADDR_LINE_SIZE){
 		//fprintf(stderr, "Reloading files ...\n");
-
-		page_cache_lock(self); // don't read while someone else is writing?
 
 		lseek(self->fd_address_file, self->num_pages*PAGE_CACHE_ADDR_LINE_SIZE, SEEK_SET);
 		offset = self->num_pages;
@@ -84,8 +79,6 @@ bool reload_addresses(page_cache_t* self){
 		munmap(self->page_data, self->num_pages*PAGE_SIZE);
 		self->num_pages = self_offset/PAGE_CACHE_ADDR_LINE_SIZE;
 		self->page_data = mmap(NULL, (self->num_pages)*PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, self->fd_page_file, 0);
-				
-		page_cache_unlock(self);
 
 		return true;
 	}

--- a/nyx/page_cache.c
+++ b/nyx/page_cache.c
@@ -359,12 +359,12 @@ page_cache_t* page_cache_new(const char* cache_file, uint8_t disassembler_word_w
 
 
 	self->lookup = kh_init(PC_CACHE);
-	self->fd_page_file = open(tmp1, O_CLOEXEC | O_CREAT | O_RDWR, 0644);
-	self->fd_address_file = open(tmp2, O_CLOEXEC | O_CREAT | O_RDWR, 0644);
+	self->fd_page_file = open(tmp1, O_CLOEXEC | O_RDWR, S_IRWXU);
+	self->fd_address_file = open(tmp2, O_CLOEXEC | O_RDWR, S_IRWXU);
 
 #ifndef STANDALONE_DECODER
 	self->cpu = cpu;
-	self->fd_lock = open(tmp3, O_CLOEXEC | O_CREAT, 0644);
+	self->fd_lock = open(tmp3, O_CLOEXEC);
 	assert(self->fd_lock > 0);
 #else
 	if(self->fd_page_file == -1 || self->fd_address_file == -1){


### PR DESCRIPTION
This PR seems to finally fix a race in page_cache.c which results in "page duplicate found" error. The issue appears reliably only with a big target, >32 VMs and any startup delays removed from libnyx/qemu.py
 
The issue is that additional read access lock in 0d98d029 is redundant (the caller is doing the lock), but then the corresponding unlock() introduces a race on page_cache changes.

The second fix is to ensure all instances create-or-open the same page_cache files. Alternative is to revert b8995723 and let the frontend ensure the files exist.