### PR TITLE
No vm_start() on snapshot restore (fixes #29)

### DIFF
--- a/nyx/fast_vm_reload.c
+++ b/nyx/fast_vm_reload.c
@@ -347,7 +347,7 @@ static void fast_reload_create_from_snapshot(fast_reload_t* self, const char* fo
     }
 
     //fast_reload_restore(self);
-    vm_start();
+    //vm_start();
 }
 
 void fast_reload_create_from_file(fast_reload_t* self, const char* folder, bool lock_iothread){


### PR DESCRIPTION
Actual vm_start() performed by caller in vl.c. This extra vm_start()
breaks "qemu -S" function in combination with snapshot loads.