### PR TITLE
more flexible nyx_abort(), start replacing hardcoded fprintf()

### DIFF
--- a/nyx/auxiliary_buffer.c
+++ b/nyx/auxiliary_buffer.c
@@ -135,7 +135,7 @@ void check_auxiliary_config_buffer(auxilary_buffer_t        *auxilary_buffer,
             uint64_t data;
             VOLATILE_READ_64(data, auxilary_buffer->configuration.page_addr);
             GET_GLOBAL_STATE()->dump_page_addr = data;
-            // fprintf(stderr, "%s dump_page_addr => 0x%lx\n", __func__, GET_GLOBAL_STATE()->dump_page_addr);
+            // nyx_debug("%s dump_page_addr => 0x%lx\n", __func__, GET_GLOBAL_STATE()->dump_page_addr);
             VOLATILE_WRITE_8(auxilary_buffer->configuration.page_dump_mode, 0);
             VOLATILE_WRITE_64(auxilary_buffer->configuration.page_addr, 0);
         }

--- a/nyx/debug.h
+++ b/nyx/debug.h
@@ -24,11 +24,9 @@
 
 #ifdef NYX_DEBUG
 /*
- * qemu_log() is the standard logging enabled with -D
+ * qemu_log() is the standard logging, forward to file with -D
  * qemu_log_mask() is activated with additional -t nyx option
  */
-// #define nyx_debug(format, ...)         qemu_log_mask(LOG_NYX, NYX_LOG_PREFIX
-// "(%s#:%d)\t"format, __BASE_FILE__, __LINE__, ##__VA_ARGS__)
 #define nyx_debug(format, ...) \
     qemu_log_mask(LOG_NYX, NYX_LOG_PREFIX format, ##__VA_ARGS__)
 #define nyx_debug_p(PREFIX, format, ...) \
@@ -38,8 +36,9 @@
 #define nyx_debug_p(...)
 #endif
 
-#define nyx_printf(format, ...) qemu_log(format, ##__VA_ARGS__)
-#define nyx_error(format, ...)  error_printf(format, ##__VA_ARGS__)
+#define nyx_printf(format, ...) qemu_log(NYX_LOG_PREFIX format, ##__VA_ARGS__)
+#define nyx_error(format, ...)  qemu_log(NYX_LOG_PREFIX "Error: " format, ##__VA_ARGS__)
+#define nyx_warn(format, ...)   qemu_log(NYX_LOG_PREFIX "Warning: " format, ##__VA_ARGS__)
 #define nyx_trace(format, ...)  nyx_debug("=> %s\n", __func__)
 
 

--- a/nyx/fast_vm_reload.c
+++ b/nyx/fast_vm_reload.c
@@ -316,7 +316,7 @@ void fast_reload_serialize_to_file(fast_reload_t *self,
 
     /* sanity check */
     if (!folder_exits(folder)) {
-        nyx_debug_p(RELOAD_PREFIX, "Folder %s does not exist...failed!", folder);
+        nyx_error("Folder %s does not exist. Abort.\n", folder);
         assert(0);
     }
 
@@ -348,7 +348,7 @@ static void fast_reload_create_from_snapshot(fast_reload_t *self,
     wait_for_snapshot(folder);
 
     nyx_debug_p(RELOAD_PREFIX,
-                "=> CREATING FAST RELOAD SNAPSHOT FROM DUMP (located in: %s)", folder);
+                "=> CREATING FAST RELOAD SNAPSHOT FROM DUMP (location: %s)\n", folder);
 
     rcu_read_lock();
 

--- a/nyx/fast_vm_reload_sync.c
+++ b/nyx/fast_vm_reload_sync.c
@@ -304,8 +304,7 @@ bool check_if_relood_request_exists_pre(fast_vm_reload_sync_t *self)
 
         switch (self->current_request) {
         case REQUEST_VOID:
-            nyx_error("%s: REQUEST_VOID requested!\n", __func__);
-            abort();
+            nyx_abort("%s: REQUEST_VOID requested!\n", __func__);
 
         case REQUEST_SAVE_SNAPSHOT_PRE_FIX_RIP:
         case REQUEST_SAVE_SNAPSHOT_ROOT_FIX_RIP:
@@ -335,8 +334,7 @@ bool check_if_relood_request_exists_pre(fast_vm_reload_sync_t *self)
             break;
 
         default:
-            nyx_error("%s: Unkown request: %d\n", __func__, self->current_request);
-            abort();
+            nyx_abort("%s: Unkown request: %d\n", __func__, self->current_request);
         }
         return true;
     }

--- a/nyx/fast_vm_reload_sync.c
+++ b/nyx/fast_vm_reload_sync.c
@@ -304,7 +304,7 @@ bool check_if_relood_request_exists_pre(fast_vm_reload_sync_t *self)
 
         switch (self->current_request) {
         case REQUEST_VOID:
-            fprintf(stderr, "%s: REQUEST_VOID requested!\n", __func__);
+            nyx_error("%s: REQUEST_VOID requested!\n", __func__);
             abort();
 
         case REQUEST_SAVE_SNAPSHOT_PRE_FIX_RIP:
@@ -335,8 +335,7 @@ bool check_if_relood_request_exists_pre(fast_vm_reload_sync_t *self)
             break;
 
         default:
-            fprintf(stderr, "%s: Unkown request: %d\n", __func__,
-                    self->current_request);
+            nyx_error("%s: Unkown request: %d\n", __func__, self->current_request);
             abort();
         }
         return true;

--- a/nyx/helpers.c
+++ b/nyx/helpers.c
@@ -1,6 +1,7 @@
 #include "qemu/osdep.h"
 
 #include <linux/kvm.h>
+#include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <sys/ioctl.h>
@@ -17,10 +18,19 @@
 #include "nyx/memory_access.h"
 #include "nyx/state/state.h"
 
-void nyx_abort(char *msg)
+void nyx_abort(const char *fmt, ...)
 {
+    static char msg[512];
+    uint32_t    msglen = 0;
+    va_list     ap;
+
+    va_start(ap, fmt);
+    msglen = vsnprintf(msg, sizeof(msg), fmt, ap);
+    va_end(ap);
+
+    nyx_error("%s\n", msg);
     set_abort_reason_auxiliary_buffer(GET_GLOBAL_STATE()->auxilary_buffer, msg,
-                                      strlen(msg));
+                                      msglen);
     synchronization_lock();
     exit(1);
 }
@@ -28,11 +38,7 @@ void nyx_abort(char *msg)
 bool is_called_in_fuzzing_mode(const char *hypercall)
 {
     if (GET_GLOBAL_STATE()->in_fuzzing_mode) {
-        char *tmp = NULL;
-        assert(asprintf(&tmp, "Hypercall <%s> called during fuzzing...", hypercall) !=
-               -1);
-        nyx_abort((char *)tmp);
-        free(tmp);
+        nyx_abort("Hypercall <%s> not allowed during fuzzing!", hypercall);
         return true;
     }
     return false;

--- a/nyx/helpers.c
+++ b/nyx/helpers.c
@@ -177,9 +177,8 @@ bool apply_capabilities(CPUState *cpu)
         }
 
         if (GET_GLOBAL_STATE()->cap_compile_time_tracing_buffer_vaddr & 0xfff) {
-            nyx_error(
-                "Error: Guest trace bitmap v_addr (0x%lx) is not page aligned!\n",
-                GET_GLOBAL_STATE()->cap_compile_time_tracing_buffer_vaddr);
+            nyx_error("Guest trace bitmap v_addr (0x%lx) is not page aligned!\n",
+                      GET_GLOBAL_STATE()->cap_compile_time_tracing_buffer_vaddr);
             return false;
         }
 
@@ -203,9 +202,8 @@ bool apply_capabilities(CPUState *cpu)
                   GET_GLOBAL_STATE()->cap_ijon_tracing_buffer_vaddr);
 
         if (GET_GLOBAL_STATE()->cap_ijon_tracing_buffer_vaddr & 0xfff) {
-            nyx_error(
-                "Error: Guest ijon buffer v_addr (0x%lx) is not page aligned!\n",
-                GET_GLOBAL_STATE()->cap_ijon_tracing_buffer_vaddr);
+            nyx_error("Guest ijon buffer v_addr (0x%lx) is not page aligned!\n",
+                      GET_GLOBAL_STATE()->cap_ijon_tracing_buffer_vaddr);
             return false;
         }
 

--- a/nyx/helpers.c
+++ b/nyx/helpers.c
@@ -177,8 +177,9 @@ bool apply_capabilities(CPUState *cpu)
         }
 
         if (GET_GLOBAL_STATE()->cap_compile_time_tracing_buffer_vaddr & 0xfff) {
-            fprintf(stderr, "[QEMU-Nyx] Error: guest's trace bitmap v_addr (0x%lx) is not page aligned!\n",
-                    GET_GLOBAL_STATE()->cap_compile_time_tracing_buffer_vaddr);
+            nyx_error(
+                "Error: Guest trace bitmap v_addr (0x%lx) is not page aligned!\n",
+                GET_GLOBAL_STATE()->cap_compile_time_tracing_buffer_vaddr);
             return false;
         }
 
@@ -202,9 +203,9 @@ bool apply_capabilities(CPUState *cpu)
                   GET_GLOBAL_STATE()->cap_ijon_tracing_buffer_vaddr);
 
         if (GET_GLOBAL_STATE()->cap_ijon_tracing_buffer_vaddr & 0xfff) {
-            error_printf("[QEMU-Nyx] Error: guest's ijon buffer v_addr (0x%lx) is "
-                         "not page aligned!\n",
-                         GET_GLOBAL_STATE()->cap_ijon_tracing_buffer_vaddr);
+            nyx_error(
+                "Error: Guest ijon buffer v_addr (0x%lx) is not page aligned!\n",
+                GET_GLOBAL_STATE()->cap_ijon_tracing_buffer_vaddr);
             return false;
         }
 

--- a/nyx/helpers.h
+++ b/nyx/helpers.h
@@ -7,7 +7,7 @@ typedef struct nyx_coverage_bitmap_copy_s {
     void *ijon_bitmap_buffer;
 } nyx_coverage_bitmap_copy_t;
 
-void nyx_abort(char *msg);
+void nyx_abort(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
 bool is_called_in_fuzzing_mode(const char *hypercall);
 
 nyx_coverage_bitmap_copy_t *new_coverage_bitmaps(void);

--- a/nyx/hypercall/configuration.c
+++ b/nyx/hypercall/configuration.c
@@ -56,17 +56,13 @@ void handle_hypercall_kafl_set_agent_config(struct kvm_run *run,
 
     if (read_virtual_memory(vaddr, (uint8_t *)&config, sizeof(agent_config_t), cpu)) {
         if (config.agent_magic != NYX_AGENT_MAGIC) {
-            nyx_error("Error: NYX_AGENT_MAGIC not found in agent configuration"
-                      " - You are probably using an outdated agent...\n");
-            exit(1);
+            nyx_abort("NYX_AGENT_MAGIC mismatch - agent outdated? (%x != %x)\n",
+                      config.agent_magic, NYX_AGENT_MAGIC);
         }
 
         if (config.agent_version != NYX_AGENT_VERSION) {
-            nyx_error("Error: NYX_AGENT_VERSION does not match in agent "
-                      "configuration (%d != %d) - "
-                      "You are probably using an outdated agent...\n",
+            nyx_abort("NYX_AGENT_VERSION mismatch - agent outdated? (%x != %x)\n",
                       config.agent_version, NYX_AGENT_VERSION);
-            exit(1);
         }
 
         GET_GLOBAL_STATE()->cap_timeout_detection = config.agent_timeout_detection;
@@ -77,9 +73,8 @@ void handle_hypercall_kafl_set_agent_config(struct kvm_run *run,
         if (!GET_GLOBAL_STATE()->cap_compile_time_tracing &&
             !GET_GLOBAL_STATE()->nyx_fdl)
         {
-            nyx_error("Error: No Intel PT support on this KVM build and no "
+            nyx_abort("No Intel PT support on this KVM build and no "
                       "compile-time instrumentation enabled in the target\n");
-            exit(1);
         }
 
         GET_GLOBAL_STATE()->cap_ijon_tracing = config.agent_ijon_tracing;
@@ -104,7 +99,7 @@ void handle_hypercall_kafl_set_agent_config(struct kvm_run *run,
         }
 
         if (apply_capabilities(cpu) == false) {
-            nyx_abort((char *)"applying agent configuration failed...");
+            nyx_abort("Applying agent configuration failed...");
         }
 
         if (getenv("DUMP_PAYLOAD_MODE")) {
@@ -114,8 +109,7 @@ void handle_hypercall_kafl_set_agent_config(struct kvm_run *run,
         }
 
     } else {
-        nyx_error("Error: %s - failed (vaddr: 0x%lx)!\n", __func__, vaddr);
-        exit(1);
+        nyx_abort("%s - failed (vaddr: 0x%lx)!\n", __func__, vaddr);
     }
     GET_GLOBAL_STATE()->set_agent_config_done = true;
 }

--- a/nyx/hypercall/configuration.c
+++ b/nyx/hypercall/configuration.c
@@ -1,5 +1,6 @@
 #include "qemu/osdep.h"
 
+#include "nyx/debug.h"
 #include "nyx/helpers.h"
 #include "nyx/hypercall/configuration.h"
 #include "nyx/memory_access.h"
@@ -55,18 +56,16 @@ void handle_hypercall_kafl_set_agent_config(struct kvm_run *run,
 
     if (read_virtual_memory(vaddr, (uint8_t *)&config, sizeof(agent_config_t), cpu)) {
         if (config.agent_magic != NYX_AGENT_MAGIC) {
-            fprintf(stderr,
-                    "[QEMU-Nyx] Error: NYX_AGENT_MAGIC not found in agent "
-                    "configuration - You are probably using an outdated agent...\n");
+            nyx_error("Error: NYX_AGENT_MAGIC not found in agent configuration"
+                      " - You are probably using an outdated agent...\n");
             exit(1);
         }
 
         if (config.agent_version != NYX_AGENT_VERSION) {
-            fprintf(stderr,
-                    "[QEMU-Nyx] Error: NYX_AGENT_VERSION does not match in agent "
-                    "configuration (%d != %d) - "
-                    "You are probably using an outdated agent...\n",
-                    config.agent_version, NYX_AGENT_VERSION);
+            nyx_error("Error: NYX_AGENT_VERSION does not match in agent "
+                      "configuration (%d != %d) - "
+                      "You are probably using an outdated agent...\n",
+                      config.agent_version, NYX_AGENT_VERSION);
             exit(1);
         }
 
@@ -78,10 +77,8 @@ void handle_hypercall_kafl_set_agent_config(struct kvm_run *run,
         if (!GET_GLOBAL_STATE()->cap_compile_time_tracing &&
             !GET_GLOBAL_STATE()->nyx_fdl)
         {
-            fprintf(
-                stderr,
-                "[QEMU-Nyx] Error: Attempt to fuzz target without compile-time "
-                "instrumentation - Intel PT is not supported on this KVM build!\n");
+            nyx_error("Error: No Intel PT support on this KVM build and no "
+                      "compile-time instrumentation enabled in the target\n");
             exit(1);
         }
 
@@ -117,8 +114,7 @@ void handle_hypercall_kafl_set_agent_config(struct kvm_run *run,
         }
 
     } else {
-        fprintf(stderr, "[QEMU-Nyx] Error: %s - failed (vaddr: 0x%lx)!\n", __func__,
-                vaddr);
+        nyx_error("Error: %s - failed (vaddr: 0x%lx)!\n", __func__, vaddr);
         exit(1);
     }
     GET_GLOBAL_STATE()->set_agent_config_done = true;

--- a/nyx/hypercall/debug.c
+++ b/nyx/hypercall/debug.c
@@ -109,6 +109,6 @@ void handle_hypercall_kafl_debug_tmp_snapshot(struct kvm_run *run,
                                               CPUState       *cpu,
                                               uint64_t        hypercall_arg)
 {
-    nyx_abort("Error: HYPERCALL_KAFL_DEBUG_TMP not enabled!\n");
+    nyx_abort("HYPERCALL_KAFL_DEBUG_TMP not enabled!\n");
 }
 #endif

--- a/nyx/hypercall/debug.c
+++ b/nyx/hypercall/debug.c
@@ -109,11 +109,6 @@ void handle_hypercall_kafl_debug_tmp_snapshot(struct kvm_run *run,
                                               CPUState       *cpu,
                                               uint64_t        hypercall_arg)
 {
-    fprintf(stderr, "[QEMU-Nyx] Error: HYPERCALL_KAFL_DEBUG_TMP not enabled!\n");
-    set_abort_reason_auxiliary_buffer(
-        GET_GLOBAL_STATE()->auxilary_buffer,
-        (char *)"HYPERCALL_KAFL_DEBUG_TMP is not enabled.",
-        strlen("HYPERCALL_KAFL_DEBUG_TMP is not enabled."));
-    synchronization_lock();
+    nyx_abort("Error: HYPERCALL_KAFL_DEBUG_TMP not enabled!\n");
 }
 #endif

--- a/nyx/hypercall/hypercall.c
+++ b/nyx/hypercall/hypercall.c
@@ -581,7 +581,7 @@ static void handle_hypercall_kafl_lock(struct kvm_run *run,
     }
 
     if (!GET_GLOBAL_STATE()->fast_reload_pre_image) {
-        nyx_error("Skipping pre image creation (hint: set pre=on)\n");
+        nyx_debug_p(CORE_PREFIX, "Skipping pre image creation (hint: set pre=on)\n");
         return;
     }
 

--- a/nyx/hypercall/hypercall.c
+++ b/nyx/hypercall/hypercall.c
@@ -105,8 +105,7 @@ bool handle_hypercall_kafl_next_payload(struct kvm_run *run,
 
         } else {
             if (GET_GLOBAL_STATE()->set_agent_config_done == false) {
-                nyx_abort(
-                    (char *)"KVM_EXIT_KAFL_SET_AGENT_CONFIG was not called...");
+                nyx_abort("KVM_EXIT_KAFL_SET_AGENT_CONFIG was not called.");
                 return false;
             }
 
@@ -175,7 +174,7 @@ static void handle_hypercall_get_payload(struct kvm_run *run,
     }
 
     if (GET_GLOBAL_STATE()->get_host_config_done == false) {
-        nyx_abort((char *)"KVM_EXIT_KAFL_GET_HOST_CONFIG was not called...");
+        nyx_abort("KVM_EXIT_KAFL_GET_HOST_CONFIG was not called...");
         return;
     }
 
@@ -189,9 +188,7 @@ static void handle_hypercall_get_payload(struct kvm_run *run,
         // print_48_pagetables(GET_GLOBAL_STATE()->parent_cr3);
 
         if (hypercall_arg & 0xFFF) {
-            fprintf(stderr, "[QEMU-Nyx] Error: Payload buffer is not page-aligned! (0x%lx)\n",
-                    hypercall_arg);
-            abort();
+            nyx_abort("Payload buffer at 0x%lx is not page-aligned!", hypercall_arg);
         }
 
         remap_payload_buffer(hypercall_arg, cpu);
@@ -527,8 +524,7 @@ void handle_hypercall_kafl_panic(struct kvm_run *run,
             }
             synchronization_lock_crash_found();
         } else {
-            nyx_abort(
-                (char *)"Agent has crashed before initializing the fuzzing loop...");
+            nyx_abort("Agent has crashed before initializing the fuzzing loop...");
         }
     }
 }
@@ -554,22 +550,17 @@ static void handle_hypercall_kafl_panic_extended(struct kvm_run *run,
                                                  CPUState       *cpu,
                                                  uint64_t        hypercall_arg)
 {
+    read_virtual_memory(hypercall_arg, (uint8_t *)hprintf_buffer, HPRINTF_SIZE, cpu);
+
     if (fast_reload_snapshot_exists(get_fast_reload_snapshot()) &&
         GET_GLOBAL_STATE()->in_fuzzing_mode)
     {
-        read_virtual_memory(hypercall_arg, (uint8_t *)hprintf_buffer, HPRINTF_SIZE,
-                            cpu);
         set_crash_reason_auxiliary_buffer(GET_GLOBAL_STATE()->auxilary_buffer,
                                           hprintf_buffer, strlen(hprintf_buffer));
         synchronization_lock_crash_found();
     } else {
-        read_virtual_memory(hypercall_arg, (uint8_t *)hprintf_buffer, HPRINTF_SIZE,
-                            cpu);
-        char *report = NULL;
-        assert(asprintf(&report,
-                        "Agent has crashed before initializing the fuzzing loop: %s",
-                        hprintf_buffer) != -1);
-        nyx_abort(report);
+        nyx_abort("Agent has crashed before initializing the fuzzing loop: %s",
+                  hprintf_buffer);
     }
 }
 
@@ -879,13 +870,11 @@ int handle_kafl_hypercall(struct kvm_run *run,
         ret = 0;
         break;
     case KVM_EXIT_KAFL_GET_PROGRAM:
-        nyx_abort(
-            (char *)"Deprecated hypercall called (HYPERCALL_KAFL_GET_PROGRAM)...");
+        nyx_abort("Hypercall is deprecated: HYPERCALL_KAFL_GET_PROGRAM");
         ret = 0;
         break;
     case KVM_EXIT_KAFL_GET_ARGV:
-        nyx_abort(
-            (char *)"Deprecated hypercall called (HYPERCALL_KAFL_GET_ARGV)...");
+        nyx_abort("Hypercall is deprecated: HYPERCALL_KAFL_GET_ARGV");
         ret = 0;
         break;
     case KVM_EXIT_KAFL_RELEASE:
@@ -917,7 +906,7 @@ int handle_kafl_hypercall(struct kvm_run *run,
         ret = 0;
         break;
     case KVM_EXIT_KAFL_INFO:
-        nyx_abort((char *)"Deprecated hypercall called (HYPERCALL_KAFL_INFO)...");
+        nyx_abort("Hypercall is deprecated: HYPERCALL_KAFL_INFO");
         ret = 0;
         break;
     case KVM_EXIT_KAFL_NEXT_PAYLOAD:
@@ -929,12 +918,11 @@ int handle_kafl_hypercall(struct kvm_run *run,
         ret = 0;
         break;
     case KVM_EXIT_KAFL_PRINTK_ADDR:
-        nyx_abort(
-            (char *)"Deprecated hypercall called (KVM_EXIT_KAFL_PRINTK_ADDR)...");
+        nyx_abort("Hypercall is deprecated: KVM_EXIT_KAFL_PRINTK_ADDR");
         ret = 0;
         break;
     case KVM_EXIT_KAFL_PRINTK:
-        nyx_abort((char *)"Deprecated hypercall called (KVM_EXIT_KAFL_PRINTK)...");
+        nyx_abort("Hypercall is deprecated: KVM_EXIT_KAFL_PRINTK");
         ret = 0;
         break;
     case KVM_EXIT_KAFL_USER_RANGE_ADVISE:

--- a/nyx/interface.c
+++ b/nyx/interface.c
@@ -162,7 +162,7 @@ static int nyx_create_payload_buffer(nyx_interface_state *s,
     fd = open(file, O_CREAT | O_RDWR, S_IRWXU | S_IRWXG | S_IRWXO);
     assert(ftruncate(fd, buffer_size) == 0);
     stat(file, &st);
-    nyx_debug_p(INTERFACE_PREFIX, "new shm file: (max size: %lx) %lx", buffer_size,
+    nyx_debug_p(INTERFACE_PREFIX, "new shm file: (max size: %lx) %lx\n", buffer_size,
                 st.st_size);
 
     assert(buffer_size == st.st_size);
@@ -419,7 +419,7 @@ static void nyx_realize(DeviceState *dev, Error **errp)
     }
 
     if (!s->sharedir || !verify_sharedir_state(s, errp)) {
-        nyx_error("Warning: Invalid sharedir...\n");
+        nyx_warn("Invalid sharedir...\n");
     } else {
         sharedir_set_dir(GET_GLOBAL_STATE()->sharedir, s->sharedir);
     }

--- a/nyx/interface.c
+++ b/nyx/interface.c
@@ -226,7 +226,7 @@ static bool verify_workdir_state(nyx_interface_state *s, Error **errp)
     char    *tmp;
 
     if (!folder_exits(workdir)) {
-        nyx_error("Error: %s does not exist...\n", workdir);
+        nyx_error("Folder %s does not exist...\n", workdir);
         return false;
     }
 
@@ -240,7 +240,7 @@ static bool verify_workdir_state(nyx_interface_state *s, Error **errp)
 
     assert(asprintf(&tmp, "%s/interface_%d", workdir, id) != -1);
     if (!file_exits(tmp)) {
-        nyx_error("Error: %s does not exist...\n", tmp);
+        nyx_error("File %s does not exist...\n", tmp);
         free(tmp);
         return false;
     }
@@ -248,7 +248,7 @@ static bool verify_workdir_state(nyx_interface_state *s, Error **errp)
 
     assert(asprintf(&tmp, "%s/payload_%d", workdir, id) != -1);
     if (!file_exits(tmp)) {
-        nyx_error("Error: %s does not exist...\n", tmp);
+        nyx_error("File %s does not exist...\n", tmp);
         free(tmp);
         return false;
     } else {
@@ -258,7 +258,7 @@ static bool verify_workdir_state(nyx_interface_state *s, Error **errp)
 
     assert(asprintf(&tmp, "%s/bitmap_%d", workdir, id) != -1);
     if (!file_exits(tmp)) {
-        nyx_error("Error: %s does not exist...\n", tmp);
+        nyx_error("File %s does not exist...\n", tmp);
         free(tmp);
         return false;
     } else {
@@ -268,7 +268,7 @@ static bool verify_workdir_state(nyx_interface_state *s, Error **errp)
 
     assert(asprintf(&tmp, "%s/ijon_%d", workdir, id) != -1);
     if (!file_exits(tmp)) {
-        nyx_error("Error: %s does not exist...\n", tmp);
+        nyx_error("File %s does not exist...\n", tmp);
         free(tmp);
         return false;
     } else {
@@ -278,7 +278,7 @@ static bool verify_workdir_state(nyx_interface_state *s, Error **errp)
 
     assert(asprintf(&tmp, "%s/page_cache.lock", workdir) != -1);
     if (!file_exits(tmp)) {
-        nyx_error("Error: %s does not exist...", tmp);
+        nyx_error("File %s does not exist...", tmp);
         free(tmp);
         return false;
     }
@@ -286,7 +286,7 @@ static bool verify_workdir_state(nyx_interface_state *s, Error **errp)
 
     assert(asprintf(&tmp, "%s/page_cache.addr", workdir) != -1);
     if (!file_exits(tmp)) {
-        nyx_error("Error: %s does not exist...\n", tmp);
+        nyx_error("File %s does not exist...\n", tmp);
         free(tmp);
         return false;
     }
@@ -294,7 +294,7 @@ static bool verify_workdir_state(nyx_interface_state *s, Error **errp)
 
     assert(asprintf(&tmp, "%s/page_cache.dump", workdir) != -1);
     if (!file_exits(tmp)) {
-        nyx_error("Error: %s does not exist...\n", tmp);
+        nyx_error("File %s does not exist...\n", tmp);
         free(tmp);
         return false;
     }
@@ -305,7 +305,7 @@ static bool verify_workdir_state(nyx_interface_state *s, Error **errp)
 
     assert(asprintf(&tmp, "%s/redqueen_workdir_%d/", workdir, id) != -1);
     if (!folder_exits(tmp)) {
-        nyx_error("%s does not exist...\n", tmp);
+        nyx_error("Folder %s does not exist...\n", tmp);
         free(tmp);
         return false;
     } else {
@@ -343,13 +343,11 @@ static void check_ipt_range(uint8_t i)
     ret     = ioctl(kvm, KVM_VMX_PT_GET_ADDRN, NULL);
 
     if (ret == -1) {
-        nyx_error("Error: Multi range tracing is not supported!\n");
-        exit(1);
+        nyx_abort("Multi range tracing is not supported!\n");
     }
 
     if (ret < (i + 1)) {
-        nyx_error("Error: CPU supports only %d IP filters!\n", ret);
-        exit(1);
+        nyx_abort("CPU supports only %d IP filters!\n", ret);
     }
     close(kvm);
 }
@@ -360,8 +358,7 @@ static void check_available_ipt_ranges(nyx_interface_state *s)
 
     int kvm_fd = qemu_open("/dev/kvm", O_RDWR);
     if (kvm_fd == -1) {
-        nyx_error("Error: could not access KVM kernel module: %m\n");
-        exit(1);
+        nyx_abort("Could not access KVM kernel module: %m\n");
     }
 
     if (ioctl(kvm_fd, KVM_CHECK_EXTENSION, KVM_CAP_NYX_PT) == 1 &&
@@ -404,8 +401,7 @@ static void nyx_realize(DeviceState *dev, Error **errp)
 
 
     if (s->worker_id == 0xFFFF) {
-        nyx_error("Error: Invalid worker id...\n");
-        exit(1);
+        nyx_abort("Invalid worker id...\n");
     }
 
     if (s->cow_primary_size) {
@@ -414,8 +410,7 @@ static void nyx_realize(DeviceState *dev, Error **errp)
     GET_GLOBAL_STATE()->worker_id = s->worker_id;
 
     if (!s->workdir || !verify_workdir_state(s, errp)) {
-        nyx_error("Error: Invalid work dir...\n");
-        exit(1);
+        nyx_abort("Invalid work dir...\n");
     }
 
     if (!s->sharedir || !verify_sharedir_state(s, errp)) {

--- a/nyx/khash.h
+++ b/nyx/khash.h
@@ -130,6 +130,8 @@ int main() {
 #include <limits.h>
 #include <assert.h>
 
+#include "debug.h"
+
 /* compiler specific configuration */
 
 #if UINT_MAX == 0xffffffffu
@@ -358,7 +360,7 @@ static const double __ac_HASH_UPPER = 0.77;
     SCOPE void kh_write_##name(kh_##name##_t *map, const char *path) {  \
         FILE *fp = fopen(path, "wb");                                   \
         if(fp == NULL) {                                                \
-            fprintf(stderr, "[%s] Could not open file %s.\n", __func__, path);\
+            nyx_error("[%s] Could not open file %s.\n", __func__, path);\
             assert(0);                                              \
 						/*exit(EXIT_FAILURE);*/                                     \
         }                                                               \

--- a/nyx/kvm_nested.c
+++ b/nyx/kvm_nested.c
@@ -202,13 +202,13 @@ static void write_address(uint64_t address, uint64_t size, uint64_t prot)
         /* do not print guard pages or empty pages without any permissions */
         if (last_address && (CHECK_BIT(last_prot, 1) || !CHECK_BIT(last_prot, 63))) {
             if (CHECK_BIT(last_prot, 1) && !CHECK_BIT(last_prot, 63)) {
-                nyx_debug_p(NESTED_VM_PREFIX, "%016lx - %016lx %c%c%c [WARNING]",
+                nyx_debug_p(NESTED_VM_PREFIX, "%016lx - %016lx %c%c%c [WARNING]\n",
                             last_address, next_address,
                             CHECK_BIT(last_prot, 1) ? 'W' : '-',
                             CHECK_BIT(last_prot, 2) ? 'U' : 'K',
                             !CHECK_BIT(last_prot, 63) ? 'X' : '-');
             } else {
-                nyx_debug_p(NESTED_VM_PREFIX, "%016lx - %016lx %c%c%c", last_address,
+                nyx_debug_p(NESTED_VM_PREFIX, "%016lx - %016lx %c%c%c\n", last_address,
                             next_address, CHECK_BIT(last_prot, 1) ? 'W' : '-',
                             CHECK_BIT(last_prot, 2) ? 'U' : 'K',
                             !CHECK_BIT(last_prot, 63) ? 'X' : '-');
@@ -376,11 +376,11 @@ void kvm_nested_get_info(CPUState *cpu)
 
     __attribute__((unused)) struct vmcs12 *saved_vmcs =
         (struct vmcs12 *)&(env->nested_state->data);
-    nyx_debug_p(NESTED_VM_PREFIX, "VMCS host_cr3:\t%lx", saved_vmcs->host_cr3);
-    nyx_debug_p(NESTED_VM_PREFIX, "VMCS host_cr4:\t%lx", saved_vmcs->host_cr4);
-    nyx_debug_p(NESTED_VM_PREFIX, "VMCS host_ia32_efer:\t%lx",
+    nyx_debug_p(NESTED_VM_PREFIX, "VMCS host_cr3:\t%lx\n", saved_vmcs->host_cr3);
+    nyx_debug_p(NESTED_VM_PREFIX, "VMCS host_cr4:\t%lx\n", saved_vmcs->host_cr4);
+    nyx_debug_p(NESTED_VM_PREFIX, "VMCS host_ia32_efer:\t%lx\n",
                 saved_vmcs->host_ia32_efer);
-    nyx_debug_p(NESTED_VM_PREFIX, "VMCS host_cr0:\t%lx", saved_vmcs->host_cr0);
+    nyx_debug_p(NESTED_VM_PREFIX, "VMCS host_cr0:\t%lx\n", saved_vmcs->host_cr0);
 
     return;
 }

--- a/nyx/memory_access.c
+++ b/nyx/memory_access.c
@@ -373,7 +373,7 @@ bool write_virtual_memory(uint64_t address, uint8_t *data, uint32_t size, CPUSta
             cpu_get_phys_page_attrs_debug(cpu, (address & x86_64_PAGE_MASK), &attrs);
 
         if (phys_addr == INVALID_ADDRESS) {
-            nyx_debug_p(MEM_PREFIX, "phys_addr == -1:\t%lx", address);
+            nyx_debug_p(MEM_PREFIX, "phys_addr == -1:\t%lx\n", address);
             return false;
         }
 
@@ -381,7 +381,7 @@ bool write_virtual_memory(uint64_t address, uint8_t *data, uint32_t size, CPUSta
         res = address_space_rw(cpu_get_address_space(cpu, asidx), phys_addr,
                                MEMTXATTRS_UNSPECIFIED, data, l, true);
         if (res != MEMTX_OK) {
-            nyx_debug_p(MEM_PREFIX, "!MEMTX_OK:\t%lx", address);
+            nyx_debug_p(MEM_PREFIX, "!MEMTX_OK:\t%lx\n", address);
             return false;
         }
 
@@ -908,11 +908,8 @@ bool read_virtual_memory(uint64_t address, uint8_t *data, uint32_t size, CPUStat
                 len_skipped = size - amount_copied;
             }
 
-            nyx_error("Warning, read from unmapped memory:\t%lx, skipping to %lx",
-                      address, next_page);
-            nyx_debug_p(MEM_PREFIX,
-                        "Warning, read from unmapped memory:\t%lx, skipping to %lx",
-                        address, next_page);
+            nyx_warn("Read from unmapped memory addr %lx, skipping to %lx\n",
+                     address, next_page);
             memset(data + amount_copied, ' ', len_skipped);
             address += len_skipped;
             amount_copied += len_skipped;
@@ -929,8 +926,9 @@ bool read_virtual_memory(uint64_t address, uint8_t *data, uint32_t size, CPUStat
                                            phys_addr, MEMTXATTRS_UNSPECIFIED,
                                            tmp_buf, len_to_copy, 0);
         if (txt) {
-            nyx_debug_p(MEM_PREFIX, "Warning, read failed:\t%lx (%lx)", address,
-                        phys_addr);
+            nyx_debug_p(MEM_PREFIX,
+                        "Warning, read failed for virt addr %lx (phys: %lx)\n",
+                        address, phys_addr);
         }
 
         memcpy(data + amount_copied, tmp_buf, len_to_copy);
@@ -980,8 +978,8 @@ bool dump_page_cr3_ht(uint64_t address, uint8_t *data, CPUState *cpu, uint64_t c
                          MEMTXATTRS_UNSPECIFIED, data, 0x1000, 0))
     {
         if (phys_addr != INVALID_ADDRESS) {
-            nyx_error("%s: Warning, read failed:\t%lx (%lx)\n", __func__, address,
-                      phys_addr);
+            nyx_warn("%s: Read failed for virt addr %lx (phys: %lx)\n", __func__,
+                     address, phys_addr);
         }
         return false;
     }
@@ -999,8 +997,8 @@ bool dump_page_ht(uint64_t address, uint8_t *data, CPUState *cpu)
                          MEMTXATTRS_UNSPECIFIED, data, 0x1000, 0))
     {
         if (phys_addr != 0xffffffffffffffffULL) {
-            nyx_error("%s: Warning, read failed:\t%lx (%lx)\n", __func__, address,
-                      phys_addr);
+            nyx_warn("%s: Read failed for virt addr %lx (phys: %lx)\n", __func__,
+                     address, phys_addr);
         }
     }
     return true;

--- a/nyx/memory_access.c
+++ b/nyx/memory_access.c
@@ -88,23 +88,20 @@ uint64_t get_paging_phys_addr(CPUState *cpu, uint64_t cr3, uint64_t addr)
     case mm_32_protected:
         return addr & 0xFFFFFFFFULL;
     case mm_32_paging:
-        fprintf(stderr, "mem_mode: mm_32_paging not implemented!\n");
-        abort();
+        nyx_abort("mem_mode: mm_32_paging not implemented!\n");
     case mm_32_pae:
-        fprintf(stderr, "mem_mode: mm_32_pae not implemented!\n");
-        abort();
+        nyx_abort("mem_mode: mm_32_pae not implemented!\n");
     case mm_64_l4_paging:
         return get_48_paging_phys_addr(cr3, addr, false);
     case mm_64_l5_paging:
-        fprintf(stderr, "mem_mode: mm_64_l5_paging not implemented!\n");
-        abort();
+        nyx_abort("mem_mode: mm_64_l5_paging not implemented!\n");
     case mm_unkown:
-        fprintf(stderr, "mem_mode: unkown!\n");
-        abort();
+        nyx_abort("mem_mode: unkown!\n");
     }
     return 0;
 }
 
+// FIXME: seems like a duplicate of get_paging_phys_addr()?
 static uint64_t get_paging_phys_addr_snapshot(CPUState *cpu, uint64_t cr3, uint64_t addr)
 {
     if (GET_GLOBAL_STATE()->mem_mode == mm_unkown) {
@@ -115,19 +112,15 @@ static uint64_t get_paging_phys_addr_snapshot(CPUState *cpu, uint64_t cr3, uint6
     case mm_32_protected:
         return addr & 0xFFFFFFFFULL;
     case mm_32_paging:
-        fprintf(stderr, "mem_mode: mm_32_paging not implemented!\n");
-        abort();
+        nyx_abort("mem_mode: mm_32_paging not implemented!\n");
     case mm_32_pae:
-        fprintf(stderr, "mem_mode: mm_32_pae not implemented!\n");
-        abort();
+        nyx_abort("mem_mode: mm_32_pae not implemented!\n");
     case mm_64_l4_paging:
         return get_48_paging_phys_addr(cr3, addr, true);
     case mm_64_l5_paging:
-        fprintf(stderr, "mem_mode: mm_64_l5_paging not implemented!\n");
-        abort();
+        nyx_abort("mem_mode: mm_64_l5_paging not implemented!\n");
     case mm_unkown:
-        fprintf(stderr, "mem_mode: unkown!\n");
-        abort();
+        nyx_abort("mem_mode: unkown!\n");
     }
     return 0;
 }
@@ -208,10 +201,9 @@ bool remap_slot(uint64_t  addr,
         phys_addr = get_paging_phys_addr(cpu, cr3, (addr & x86_64_PAGE_MASK));
 
         if (phys_addr == INVALID_ADDRESS) {
-            fprintf(stderr, "[QEMU-Nyx] Error: failed to translate v_addr (0x%lx) to p_addr!\n",
-                    addr);
-            fprintf(stderr, "[QEMU-Nyx] Check if the buffer is present in the "
-                            "guest's memory...\n");
+            nyx_error("Failed to translate v_addr (0x%lx) to p_addr!\n"
+                      "Check if the buffer is present in the guest's memory...\n",
+                      addr);
             exit(1);
         }
     }
@@ -444,7 +436,7 @@ static int redqueen_insert_sw_breakpoint(CPUState *cs, struct kvm_sw_breakpoint 
         address_space_rw(cpu_get_address_space(cs, asidx), phys_addr,
                          MEMTXATTRS_UNSPECIFIED, (uint8_t *)&int3, 1, 1))
     {
-        // fprintf(stderr, "%s WRITTE AT %lx %lx failed!\n", __func__, bp->pc, phys_addr);
+        // nyx_debug("%s WRITE AT %lx %lx failed!\n", __func__, bp->pc, phys_addr);
         return -EINVAL;
     }
 
@@ -465,7 +457,7 @@ static int redqueen_remove_sw_breakpoint(CPUState *cs, struct kvm_sw_breakpoint 
         address_space_rw(cpu_get_address_space(cs, asidx), phys_addr,
                          MEMTXATTRS_UNSPECIFIED, (uint8_t *)&bp->saved_insn, 1, 1))
     {
-        // fprintf(stderr, "%s failed\n", __func__);
+        // nyx_debug("%s failed\n", __func__);
         return -EINVAL;
     }
 

--- a/nyx/nested_hypercalls.c
+++ b/nyx/nested_hypercalls.c
@@ -72,7 +72,7 @@ void handle_hypercall_kafl_nested_prepare(struct kvm_run *run,
     if ((uint64_t)run->hypercall.args[0]) {
         nyx_debug_p(CORE_PREFIX,
                     "handle_hypercall_kafl_nested_prepare:\t NUM:\t%lx\t "
-                    "ADDRESS:\t%lx\t CR3:\t%lx",
+                    "ADDRESS:\t%lx\t CR3:\t%lx\n",
                     (uint64_t)run->hypercall.args[0], (uint64_t)run->hypercall.args[1],
                     (uint64_t)run->hypercall.args[2]);
     } else {
@@ -91,7 +91,7 @@ void handle_hypercall_kafl_nested_prepare(struct kvm_run *run,
         if (i == 0) {
             htos_config = buffer[i];
         }
-        nyx_debug_p(CORE_PREFIX, "ADDRESS: %lx", buffer[i]);
+        nyx_debug_p(CORE_PREFIX, "ADDRESS: %lx\n", buffer[i]);
         remap_payload_slot(buffer[i], i, cpu);
     }
 

--- a/nyx/page_cache.c
+++ b/nyx/page_cache.c
@@ -247,7 +247,7 @@ page_cache_t *page_cache_new(CPUState *cpu, const char *cache_file)
     self->last_page = 0xFFFFFFFFFFFFFFFF;
     self->last_addr = 0xFFFFFFFFFFFFFFFF;
 
-    nyx_debug_p(PAGE_CACHE_PREFIX, "%s (%s - %s)", __func__, tmp1, tmp2);
+    nyx_debug_p(PAGE_CACHE_PREFIX, "%s (%s - %s)\n", __func__, tmp1, tmp2);
 
     free(tmp3);
     free(tmp2);

--- a/nyx/page_cache.c
+++ b/nyx/page_cache.c
@@ -42,15 +42,14 @@ static bool reload_addresses(page_cache_t *self)
             k = kh_get(PC_CACHE, self->lookup, addr);
             if (k == kh_end(self->lookup)) {
                 if (value & 0xFFF) {
-                    fprintf(stderr, "Load page: %lx (UNMAPPED)\n", addr);
+                    nyx_warn("Load page: %lx (UNMAPPED)\n", addr);
                 } else {
                     k = kh_put(PC_CACHE, self->lookup, addr, &ret);
                     kh_value(self->lookup, k) = (offset - 1) * PAGE_SIZE;
                 }
             } else {
                 /* likely a bug / race condition in page_cache itself! */
-                fprintf(stderr,
-                        "----------> Page duplicate found ...skipping! %lx\n", addr);
+                nyx_warn("----> Page duplicate found ...skipping! %lx\n", addr);
                 // abort();
             }
         }
@@ -119,7 +118,7 @@ static void page_cache_lock(page_cache_t *self)
             return;
         } else if (ret == EINTR) {
             /* try again if acquiring this lock has failed */
-            fprintf(stderr, "%s: interrupted by signal...\n", __func__);
+            nyx_debug("%s: interrupted by signal...\n", __func__);
         } else {
             assert(false);
         }
@@ -135,7 +134,7 @@ static void page_cache_unlock(page_cache_t *self)
             return;
         } else if (ret == EINTR) {
             /* try again if releasing this lock has failed */
-            fprintf(stderr, "%s: interrupted by signal...\n", __func__);
+            nyx_debug("%s: interrupted by signal...\n", __func__);
         } else {
             assert(false);
         }

--- a/nyx/pt.c
+++ b/nyx/pt.c
@@ -62,8 +62,8 @@ static inline int pt_cmd_hmp_context(CPUState *cpu, uint64_t cmd)
 {
     cpu->pt_ret = -1;
     if (pt_hypercalls_enabled()) {
-        nyx_debug_p(PT_PREFIX, "Error: HMP commands are ignored if kafl tracing "
-                               "mode is enabled (-kafl)!");
+        nyx_error("HMP commands are ignored if kafl tracing "
+                  "mode is enabled (-kafl)!\n");
     } else {
         cpu->pt_cmd = cmd;
         run_on_cpu(cpu, pt_set, RUN_ON_CPU_NULL);
@@ -110,16 +110,16 @@ void pt_dump(CPUState *cpu, int bytes)
                 cpu->intel_pt_run_trashed = true;
                 break;
             case decoder_page_fault:
-                // fprintf(stderr, "Page not found => 0x%lx\n", libxdc_get_page_fault_addr(GET_GLOBAL_STATE()->decoder));
+                // nyx_warn("Page not found => 0x%lx\n", libxdc_get_page_fault_addr(GET_GLOBAL_STATE()->decoder));
                 GET_GLOBAL_STATE()->decoder_page_fault = true;
                 GET_GLOBAL_STATE()->decoder_page_fault_addr =
                     libxdc_get_page_fault_addr(GET_GLOBAL_STATE()->decoder);
                 break;
             case decoder_unkown_packet:
-                fprintf(stderr, "WARNING: libxdc_decode returned unknown_packet\n");
+                nyx_warn("WARNING: libxdc_decode returned unknown_packet\n");
                 break;
             case decoder_error:
-                fprintf(stderr, "WARNING: libxdc_decode returned decoder_error\n");
+                nyx_warn("WARNING: libxdc_decode returned decoder_error\n");
                 break;
             }
         }
@@ -158,7 +158,7 @@ int pt_set_cr3(CPUState *cpu, uint64_t val, bool hmp_mode)
         return -EINVAL;
     }
     if (GET_GLOBAL_STATE()->pt_c3_filter && GET_GLOBAL_STATE()->pt_c3_filter != val) {
-        // nyx_debug_p(PT_PREFIX, "Reconfigure CR3-Filtering!");
+        // nyx_debug_p(PT_PREFIX, "Reconfigure CR3-Filtering!\n");
         GET_GLOBAL_STATE()->pt_c3_filter = val;
         r += pt_cmd(cpu, KVM_VMX_PT_CONFIGURE_CR3, hmp_mode);
         r += pt_cmd(cpu, KVM_VMX_PT_ENABLE_CR3, hmp_mode);
@@ -185,7 +185,7 @@ int pt_enable_ip_filtering(CPUState *cpu, uint8_t addrn, bool redqueen, bool hmp
     if (GET_GLOBAL_STATE()->pt_ip_filter_a[addrn] >
         GET_GLOBAL_STATE()->pt_ip_filter_b[addrn])
     {
-        nyx_debug_p(PT_PREFIX, "Error (ip_a > ip_b) 0x%lx-0x%lx",
+        nyx_debug_p(PT_PREFIX, "Error (ip_a > ip_b) 0x%lx-0x%lx\n",
                     GET_GLOBAL_STATE()->pt_ip_filter_a[addrn],
                     GET_GLOBAL_STATE()->pt_ip_filter_b[addrn]);
         return -EINVAL;
@@ -195,7 +195,7 @@ int pt_enable_ip_filtering(CPUState *cpu, uint8_t addrn, bool redqueen, bool hmp
         pt_disable_ip_filtering(cpu, addrn, hmp_mode);
     }
 
-    nyx_debug_p(PT_PREFIX, "Configuring new trace region (addr%d, 0x%lx-0x%lx)",
+    nyx_debug_p(PT_PREFIX, "Configuring new trace region (addr%d, 0x%lx-0x%lx)\n",
                 addrn, GET_GLOBAL_STATE()->pt_ip_filter_a[addrn],
                 GET_GLOBAL_STATE()->pt_ip_filter_b[addrn]);
 
@@ -287,20 +287,20 @@ void pt_pre_kvm_run(CPUState *cpu)
     struct vmx_pt_filter_iprs filter_iprs;
 
     if (GET_GLOBAL_STATE()->patches_disable_pending) {
-        // nyx_debug_p(REDQUEEN_PREFIX, "patches disable");
+        // nyx_debug_p(REDQUEEN_PREFIX, "patches disable\n");
         assert(false); /* remove this branch */
         GET_GLOBAL_STATE()->patches_disable_pending = false;
     }
 
     if (GET_GLOBAL_STATE()->patches_enable_pending) {
-        // nyx_debug_p(REDQUEEN_PREFIX, "patches enable");
+        // nyx_debug_p(REDQUEEN_PREFIX, "patches enable\n");
         assert(false); /* remove this branch */
         GET_GLOBAL_STATE()->patches_enable_pending = false;
     }
 
 
     if (GET_GLOBAL_STATE()->redqueen_enable_pending) {
-        // nyx_debug_p(REDQUEEN_PREFIX, "rq enable");
+        // nyx_debug_p(REDQUEEN_PREFIX, "rq enable\n");
         if (GET_GLOBAL_STATE()->redqueen_state) {
             enable_rq_intercept_mode(GET_GLOBAL_STATE()->redqueen_state);
         }
@@ -308,7 +308,7 @@ void pt_pre_kvm_run(CPUState *cpu)
     }
 
     if (GET_GLOBAL_STATE()->redqueen_disable_pending) {
-        // nyx_debug_p(REDQUEEN_PREFIX, "rq disable");
+        // nyx_debug_p(REDQUEEN_PREFIX, "rq disable\n");
         if (GET_GLOBAL_STATE()->redqueen_state) {
             disable_rq_intercept_mode(GET_GLOBAL_STATE()->redqueen_state);
         }
@@ -352,7 +352,7 @@ void pt_pre_kvm_run(CPUState *cpu)
                 if (cpu->pt_fd) {
                     ret = ioctl(cpu->pt_fd, cpu->pt_cmd, 0);
                     if (ret > 0) {
-                        // nyx_debug_p(PT_PREFIX, "KVM_VMX_PT_DISABLE %d", ret);
+                        // nyx_debug_p(PT_PREFIX, "KVM_VMX_PT_DISABLE %d\n", ret);
                         pt_dump(cpu, ret);
                         cpu->pt_enabled = false;
                     }

--- a/nyx/redqueen.c
+++ b/nyx/redqueen.c
@@ -99,7 +99,7 @@ static bool is_interessting_lea_at(redqueen_t *self, cs_insn *ins)
         if (reg == X86_REG_EIP || reg == X86_REG_RIP || reg == X86_REG_EBP ||
             reg == X86_REG_RBP)
         {
-            // nyx_debug_p(REDQUEEN_PREFIX, "got boring index");
+            // nyx_debug_p(REDQUEEN_PREFIX, "got boring index\n");
             res = false;
         } // don't instrument local stack offset computations
     }
@@ -198,26 +198,26 @@ static void opcode_analyzer(redqueen_t *self, cs_insn *ins)
     // printf("INS %lx\n", ins->address);
     if (ins->id == X86_INS_CMP) {
         set_rq_instruction(self, ins->address);
-        // nyx_debug_p(REDQUEEN_PREFIX, "hooking cmp %lx %s %s", ins->address, ins->mnemonic, ins->op_str);
+        // nyx_debug_p(REDQUEEN_PREFIX, "hooking cmp %lx %s %s\n", ins->address, ins->mnemonic, ins->op_str);
     }
     if (ins->id == X86_INS_LEA && is_interessting_lea_at(self, ins)) {
-        // nyx_debug_p(REDQUEEN_PREFIX, "hooking lea %lx", ins->address);
+        // nyx_debug_p(REDQUEEN_PREFIX, "hooking lea %lx\n", ins->address);
         set_rq_instruction(self, ins->address);
     }
     if (ins->id == X86_INS_SUB && is_interessting_sub_at(self, ins)) {
-        // nyx_debug_p(REDQUEEN_PREFIX, "hooking sub %lx", ins->address);
+        // nyx_debug_p(REDQUEEN_PREFIX, "hooking sub %lx\n", ins->address);
         set_rq_instruction(self, ins->address);
     }
     if (ins->id == X86_INS_ADD && is_interessting_add_at(self, ins)) {
-        // nyx_debug_p(REDQUEEN_PREFIX, "hooking add %lx", ins->address);
+        // nyx_debug_p(REDQUEEN_PREFIX, "hooking add %lx\n", ins->address);
         set_rq_instruction(self, ins->address);
     }
     if (ins->id == X86_INS_XOR && is_interessting_xor_at(self, ins)) {
-        // nyx_debug_p(REDQUEEN_PREFIX, "hooking xor %lx %s %s", ins->address, ins->mnemonic, ins->op_str);
+        // nyx_debug_p(REDQUEEN_PREFIX, "hooking xor %lx %s %s\n", ins->address, ins->mnemonic, ins->op_str);
         set_rq_instruction(self, ins->address);
     }
     if (ins->id == X86_INS_CALL || ins->id == X86_INS_LCALL) {
-        // nyx_debug_p(REDQUEEN_PREFIX, "hooking call %lx %s %s", ins->address, ins->mnemonic, ins->op_str);
+        // nyx_debug_p(REDQUEEN_PREFIX, "hooking call %lx %s %s\n", ins->address, ins->mnemonic, ins->op_str);
         set_rq_instruction(self, ins->address);
     }
 }
@@ -346,7 +346,7 @@ static void insert_hooks_bitmap(redqueen_t *self)
 
 void redqueen_insert_hooks(redqueen_t *self)
 {
-    nyx_debug_p(REDQUEEN_PREFIX, "insert hooks");
+    nyx_debug_p(REDQUEEN_PREFIX, "insert hooks\n");
     assert(!self->hooks_applied);
     switch (GET_GLOBAL_STATE()->redqueen_instrumentation_mode) {
     case (REDQUEEN_LIGHT_INSTRUMENTATION):
@@ -365,7 +365,7 @@ void redqueen_insert_hooks(redqueen_t *self)
 
 void redqueen_remove_hooks(redqueen_t *self)
 {
-    nyx_debug_p(REDQUEEN_PREFIX, "remove hooks");
+    nyx_debug_p(REDQUEEN_PREFIX, "remove hooks\n");
     assert(self->hooks_applied);
     remove_all_breakpoints(self->cpu);
 
@@ -738,7 +738,7 @@ static uint64_t eval_mem(cs_x86_op *op)
 {
     uint64_t val = 0;
     assert(op->size == 1 || op->size == 2 || op->size == 4 || op->size == 8);
-    // nyx_debug_p(REDQUEEN_PREFIX, "EVAL MEM FOR OP:");
+    // nyx_debug_p(REDQUEEN_PREFIX, "EVAL MEM FOR OP:\n");
 
     /* TODO @ sergej: replace me later */
     read_virtual_memory(eval_addr(op), (uint8_t *)&val, op->size, qemu_get_cpu(0));
@@ -787,7 +787,7 @@ static void print_comp_result(uint64_t    addr,
 
     uint8_t pos = 0;
     pos += snprintf(result_buf + pos, 256 - pos, "%lx\t\t %s", addr, type);
-    // nyx_debug_p(REDQUEEN_PREFIX, "got size: %ld", size);
+    // nyx_debug_p(REDQUEEN_PREFIX, "got size: %ld\n", size);
     uint64_t mask = 0;
     switch (size) {
     case 64:
@@ -993,7 +993,7 @@ static bool test_strcmp(uint64_t arg1, uint64_t arg2)
     if (!is_addr_mapped(arg1, cpu) || !is_addr_mapped(arg2, cpu)) {
         return false;
     }
-    // nyx_debug_p(REDQUEEN_PREFIX,"valid ptrs");
+    // nyx_debug_p(REDQUEEN_PREFIX,"valid ptrs\n");
     uint8_t buf1[REDQUEEN_MAX_STRCMP_LEN];
     uint8_t buf2[REDQUEEN_MAX_STRCMP_LEN];
     /* TODO @ sergej */
@@ -1007,7 +1007,7 @@ static bool test_strcmp_cdecl(void)
 {
     uint64_t arg1 = read_stack(0);
     uint64_t arg2 = read_stack(1);
-    // nyx_debug_p(REDQUEEN_PREFIX, "extract call params cdecl %lx %lx", arg1, arg2);
+    // nyx_debug_p(REDQUEEN_PREFIX, "extract call params cdecl %lx %lx\n", arg1, arg2);
     test_strchr(arg1, arg2);
     return test_strcmp(arg1, arg2);
 }
@@ -1017,7 +1017,7 @@ static bool test_strcmp_fastcall(void)
     CPUX86State *env  = &(X86_CPU(qemu_get_cpu(0)))->env;
     uint64_t     arg1 = env->regs[RCX]; // rcx
     uint64_t     arg2 = env->regs[RDX]; // rdx
-    // nyx_debug_p(REDQUEEN_PREFIX, "extract call params fastcall %lx %lx", arg1, arg2);
+    // nyx_debug_p(REDQUEEN_PREFIX, "extract call params fastcall %lx %lx\n", arg1, arg2);
     test_strchr(arg1, arg2);
     return test_strcmp(arg1, arg2);
 }
@@ -1030,14 +1030,14 @@ static bool test_strcmp_sys_v(void)
     CPUX86State *env  = &(X86_CPU(qemu_get_cpu(0)))->env;
     uint64_t     arg1 = env->regs[RDI]; // rdx
     uint64_t     arg2 = env->regs[RSI]; // rsi
-    // nyx_debug_p(REDQUEEN_PREFIX, "extract call params sysv %lx %lx", arg1, arg2);
+    // nyx_debug_p(REDQUEEN_PREFIX, "extract call params sysv %lx %lx\n", arg1, arg2);
     test_strchr(arg1, arg2);
     return test_strcmp(arg1, arg2);
 }
 
 static void extract_call_params(void)
 {
-    // nyx_debug_p(REDQUEEN_PREFIX, "extract call at %lx", ip);
+    // nyx_debug_p(REDQUEEN_PREFIX, "extract call at %lx\n", ip);
     test_strcmp_cdecl();
     test_strcmp_fastcall();
     test_strcmp_sys_v();

--- a/nyx/redqueen_trace.c
+++ b/nyx/redqueen_trace.c
@@ -56,7 +56,6 @@ static void alt_bitmap_add(uint64_t from, uint64_t to)
     }
 }
 
-
 static int reset_trace_fd(void)
 {
     if (trace_fd)
@@ -64,7 +63,7 @@ static int reset_trace_fd(void)
     trace_fd =
         open(redqueen_workdir.pt_trace_results, O_WRONLY | O_CREAT | O_TRUNC, 0644);
     if (trace_fd < 0) {
-        fprintf(stderr, "Failed to initiate trace output: %s\n", strerror(errno));
+        nyx_error("Failed to initiate trace output: %s\n", strerror(errno));
         assert(0);
     }
     return trace_fd;

--- a/nyx/sharedir.c
+++ b/nyx/sharedir.c
@@ -138,8 +138,7 @@ static FILE *get_file_ptr(sharedir_t *self, sharedir_file_t *obj)
 uint64_t sharedir_request_file(sharedir_t *self, const char *file, uint8_t *page_buffer)
 {
     if (!self->dir) {
-        fprintf(stderr, "WARNING: New file request received, but no share dir configured! [FILE: %s]\n",
-                file);
+        nyx_error("Guest requests file <%s> but no sharedir configured!\n", file);
         return 0xFFFFFFFFFFFFFFFFUL;
     }
 
@@ -148,10 +147,10 @@ uint64_t sharedir_request_file(sharedir_t *self, const char *file, uint8_t *page
     sharedir_file_t *obj = sharedir_get_object(self, file);
     if (obj != NULL) {
 #ifdef SHAREDIR_DEBUG
-        printf("sharedir_get_object->file: %s\n", obj->file);
-        printf("sharedir_get_object->path: %s\n", obj->path);
-        printf("sharedir_get_object->size: %ld\n", obj->size);
-        printf("sharedir_get_object->bytes_left: %ld\n", obj->bytes_left);
+        nyx_debug("sharedir_get_object->file: %s\n", obj->file);
+        nyx_debug("sharedir_get_object->path: %s\n", obj->path);
+        nyx_debug("sharedir_get_object->size: %ld\n", obj->size);
+        nyx_debug("sharedir_get_object->bytes_left: %ld\n", obj->bytes_left);
 #endif
         if (obj->bytes_left >= 0x1000) {
             f = get_file_ptr(self, obj);
@@ -175,7 +174,7 @@ uint64_t sharedir_request_file(sharedir_t *self, const char *file, uint8_t *page
             }
         }
     } else {
-        nyx_error("Warning: No such file in sharedir: %s\n", file);
+        nyx_error("No such file in sharedir: %s\n", file);
         return 0xFFFFFFFFFFFFFFFFUL;
     }
 }

--- a/nyx/snapshot/devices/state_reallocation.c
+++ b/nyx/snapshot/devices/state_reallocation.c
@@ -685,7 +685,7 @@ static int fdl_vmstate_load_state(state_reallocation_t     *self,
                 }
             }
         } else if (field->flags & VMS_MUST_EXIST) {
-            nyx_debug("Input validation failed: %s/%s", vmsd->name, field->name);
+            nyx_debug("Input validation failed: %s/%s\n", vmsd->name, field->name);
             return -1;
         } else {
             // printf("Field does not exist...\n");

--- a/nyx/snapshot/memory/backend/nyx_debug.c
+++ b/nyx/snapshot/memory/backend/nyx_debug.c
@@ -61,7 +61,7 @@ uint32_t nyx_snapshot_debug_restore(shadow_memory_t           *shadow_memory_sta
                 if (snapshot_page_blocklist_check_phys_addr(blocklist,
                                                             physical_addr) == false)
                 {
-                    // fprintf(stderr, "(2) DIRTY: 0x%lx (NUM: %d - OFFSET: 0x%lx)\n", physical_addr, i, addr);
+                    // nyx_debug("(2) DIRTY: 0x%lx (NUM: %d - OFFSET: 0x%lx)\n", physical_addr, i, addr);
 
                     if (verbose) {
                         printf("%s -> (phys: 0x%lx) %p <-- %p [%d]\n", __func__,
@@ -113,7 +113,7 @@ void nyx_snapshot_debug_save_root_pages(shadow_memory_t *shadow_memory_state,
                 if (snapshot_page_blocklist_check_phys_addr(blocklist,
                                                             physical_addr) == false)
                 {
-                    // fprintf(stderr, "(2) DIRTY: 0x%lx (NUM: %d - OFFSET: 0x%lx)\n", physical_addr, i, addr);
+                    // nyx_debug("(2) DIRTY: 0x%lx (NUM: %d - OFFSET: 0x%lx)\n", physical_addr, i, addr);
 
                     if (verbose &&
                         !shadow_memory_is_root_page_tracked(shadow_memory_state,

--- a/nyx/snapshot/memory/block_list.c
+++ b/nyx/snapshot/memory/block_list.c
@@ -44,7 +44,7 @@ snapshot_page_blocklist_t *snapshot_page_blocklist_init(void)
 void snapshot_page_blocklist_add(snapshot_page_blocklist_t *self, uint64_t phys_addr)
 {
     if (phys_addr == -1) {
-        fprintf(stderr, "ERROR %s: phys_addr=%lx\n", __func__, phys_addr);
+        nyx_error("%s: phys_addr=%lx\n", __func__, phys_addr);
         return;
     }
     assert(self != NULL);

--- a/nyx/snapshot/memory/shadow_memory.c
+++ b/nyx/snapshot/memory/shadow_memory.c
@@ -8,6 +8,7 @@
 #include "qemu/rcu_queue.h"
 
 #include "nyx/debug.h"
+#include "nyx/helpers.h"
 #include "nyx/memory_access.h"
 
 #include "nyx/snapshot/helper.h"
@@ -187,13 +188,7 @@ shadow_memory_t *shadow_memory_init_from_snapshot(const char *snapshot_folder,
     assert(fread(&head, sizeof(fast_reload_dump_head_t), 1, file_mem_meta) == 1);
     fclose(file_mem_meta);
 
-    if (self->ram_regions_num != head.shadow_memory_regions) {
-        nyx_error(
-            "Error: self->ram_regions_num (%d) != head.shadow_memory_regions (%d)\n",
-            self->ram_regions_num, head.shadow_memory_regions);
-        exit(1);
-    }
-
+    assert(self->ram_regions_num == head.shadow_memory_regions);
     // printf("LOAD -> self->ram_regions_num: %d\n", self->ram_regions_num);
 
     FILE *file_mem_dump = fopen(path_dump, "r");
@@ -208,13 +203,12 @@ shadow_memory_t *shadow_memory_init_from_snapshot(const char *snapshot_folder,
 
     if (self->memory_size != file_mem_dump_size) {
         if (file_mem_dump_size >= VGA_SIZE) {
-            nyx_error("ERROR: guest size should be %ld MB - set it to %ld MB\n",
+            nyx_abort("Guest size should be %ld MB - set it to %ld MB\n",
                       (file_mem_dump_size - VGA_SIZE) >> 20,
                       (self->memory_size - VGA_SIZE) >> 20);
-            exit(1);
         } else {
-            nyx_error("ERROR: guest size: %ld bytes\n", file_mem_dump_size);
-            exit(1);
+            nyx_abort("Guest mem size != file size: %ld != %ld bytes\n",
+                      self->memory_size, file_mem_dump_size);
         }
     }
     assert(self->memory_size == ftell(file_mem_dump));

--- a/nyx/snapshot/memory/shadow_memory.c
+++ b/nyx/snapshot/memory/shadow_memory.c
@@ -73,7 +73,7 @@ shadow_memory_t *shadow_memory_init(void)
                               MAP_SHARED, self->snapshot_ptr_fd, 0);
     madvise(self->snapshot_ptr, self->memory_size, MADV_RANDOM | MADV_MERGEABLE);
 
-    nyx_debug_p(RELOAD_PREFIX, "Allocating Memory (%p) Size: %lx",
+    nyx_debug_p(RELOAD_PREFIX, "Allocating Memory (%p) Size: %lx\n",
                 self->snapshot_ptr, self->memory_size);
 
 
@@ -81,7 +81,7 @@ shadow_memory_t *shadow_memory_init(void)
     uint8_t  i           = 0;
     uint8_t  regions_num = 0;
     QLIST_FOREACH_RCU (block, &ram_list.blocks, next) {
-        nyx_debug_p(RELOAD_PREFIX, "%lx %lx %lx\t%s\t%p", block->offset,
+        nyx_debug_p(RELOAD_PREFIX, "%lx %lx %lx\t%s\t%p\n", block->offset,
                     block->used_length, block->max_length, block->idstr, block->host);
         block_array[i] = block;
 
@@ -233,7 +233,7 @@ shadow_memory_t *shadow_memory_init_from_snapshot(const char *snapshot_folder,
     uint8_t  i           = 0;
     uint8_t  regions_num = 0;
     QLIST_FOREACH_RCU (block, &ram_list.blocks, next) {
-        nyx_debug_p(RELOAD_PREFIX, "%lx %lx %lx\t%s\t%p", block->offset,
+        nyx_debug_p(RELOAD_PREFIX, "%lx %lx %lx\t%s\t%p\n", block->offset,
                     block->used_length, block->max_length, block->idstr, block->host);
 
         block_array[i]                 = block;

--- a/nyx/state/snapshot_state.c
+++ b/nyx/state/snapshot_state.c
@@ -144,7 +144,7 @@ void deserialize_state(const char *filename_prefix)
         nyx_global_state->get_host_config_done  = true;
         nyx_global_state->set_agent_config_done = true;
     } else {
-        fprintf(stderr, "[QEMU-Nyx]: this feature is currently missing\n");
+        nyx_error("this feature is currently missing\n");
         abort();
     }
 

--- a/nyx/state/state.c
+++ b/nyx/state/state.c
@@ -220,13 +220,13 @@ static void *alloc_auxiliary_buffer(const char *file)
     assert(ftruncate(fd, AUX_BUFFER_SIZE) == 0);
     stat(file, &st);
 
-    nyx_debug_p(INTERFACE_PREFIX, "new aux buffer file: (max size: %x) %lx",
+    nyx_debug_p(INTERFACE_PREFIX, "new aux buffer file: (max size: %x) %lx\n",
                 AUX_BUFFER_SIZE, st.st_size);
 
     assert(AUX_BUFFER_SIZE == st.st_size);
     ptr = mmap(0, AUX_BUFFER_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     if (ptr == MAP_FAILED) {
-        fprintf(stderr, "aux buffer allocation failed!\n");
+        nyx_error("aux buffer allocation failed!\n");
         return (void *)-1;
     }
     return ptr;

--- a/nyx/state/state.c
+++ b/nyx/state/state.c
@@ -33,8 +33,6 @@ along with QEMU-PT.  If not, see <http://www.gnu.org/licenses/>.
 #include "nyx/sharedir.h"
 #include "nyx/state/state.h"
 
-// #define STATE_VERBOSE
-
 /* global singleton */
 qemu_nyx_state_t global_state;
 
@@ -42,9 +40,8 @@ qemu_nyx_state_t global_state;
 
 void state_init_global(void)
 {
-#ifdef STATE_VERBOSE
-    fprintf(stderr, "--> %s <--\n", __func__);
-#endif
+    nyx_trace();
+
     /* safety first */
     assert(libxdc_get_release_version() == LIBXDC_RELEASE_VERSION_REQUIRED);
 

--- a/nyx/trace_dump.c
+++ b/nyx/trace_dump.c
@@ -25,7 +25,7 @@ void pt_trace_dump_init(char *filename)
 {
     int test_fd;
 
-    nyx_debug("Enable pt trace dump at %s", filename);
+    nyx_debug("Enable pt trace dump at %s\n", filename);
     pt_dump_initialized = true;
 
     test_fd = open(filename, O_CREAT | O_TRUNC | O_WRONLY, 0644);

--- a/nyx/trace_dump.c
+++ b/nyx/trace_dump.c
@@ -30,9 +30,8 @@ void pt_trace_dump_init(char *filename)
 
     test_fd = open(filename, O_CREAT | O_TRUNC | O_WRONLY, 0644);
     if (test_fd < 0)
-        fprintf(stderr, "Error accessing pt_dump output path %s: %s",
-                pt_trace_dump_filename, strerror(errno));
-    assert(test_fd >= 0);
+        nyx_abort("Error accessing pt_dump output path %s: %s",
+                  pt_trace_dump_filename, strerror(errno));
 
     pt_trace_dump_filename = strdup(filename);
     assert(pt_trace_dump_filename);
@@ -47,9 +46,8 @@ void pt_truncate_pt_dump_file(void)
 
     fd = open(pt_trace_dump_filename, O_CREAT | O_TRUNC | O_WRONLY, 0644);
     if (fd < 0) {
-        fprintf(stderr, "Error truncating %s: %s\n", pt_trace_dump_filename,
-                strerror(errno));
-        assert(0);
+        nyx_abort("Error truncating %s: %s\n", pt_trace_dump_filename,
+                  strerror(errno));
     }
     close(fd);
 }
@@ -63,9 +61,8 @@ void pt_write_pt_dump_file(uint8_t *data, size_t bytes)
 
     fd = open(pt_trace_dump_filename, O_APPEND | O_WRONLY, 0644);
     if (fd < 0) {
-        fprintf(stderr, "Error writing pt_trace_dump to %s: %s\n",
-                pt_trace_dump_filename, strerror(errno));
-        assert(0);
+        nyx_abort("Error writing pt_trace_dump to %s: %s\n", pt_trace_dump_filename,
+                  strerror(errno));
     }
     assert(bytes == write(fd, data, bytes));
     close(fd);

--- a/vl.c
+++ b/vl.c
@@ -4632,32 +4632,32 @@ int main(int argc, char **argv, char **envp)
         if ((snapshot_used || load_mode || skip_serialization) &&
             getenv("NYX_DISABLE_DIRTY_RING"))
         {
-            error_report("NYX_DISABLE_DIRTY_RING is only allowed during "
-                         "pre-snapshot creation\n");
+            nyx_error("NYX_DISABLE_DIRTY_RING is only allowed during "
+                      "pre-snapshot creation\n");
             exit(1);
         }
 
         if ((pre_snapshot_used && !snapshot_used && !load_mode) &&
             !getenv("NYX_DISABLE_DIRTY_RING"))
         {
-            error_report(
+            nyx_error(
                 "NYX_DISABLE_DIRTY_RING is required during pre-snapshot creation\n");
             exit(1);
         }
 
         if (pre_snapshot_used && load_mode) {
-            error_report("invalid argument (pre_snapshot_used && load_mode)!\n");
+            nyx_error("invalid argument (pre_snapshot_used && load_mode)!\n");
             exit(1);
         }
 
         if ((!snapshot_used && !pre_snapshot_used) && load_mode) {
-            error_report("invalid argument ((!pre_snapshot_used && "
-                         "!pre_snapshot_used) && load_mode)!\n");
+            nyx_error("invalid argument ((!pre_snapshot_used && "
+                      "!pre_snapshot_used) && load_mode)!\n");
             exit(1);
         }
 
         if (pre_snapshot_used && snapshot_used) {
-            nyx_printf("[Qemu-Nyx]: loading pre image to start fuzzing...\n");
+            nyx_printf("Loading pre image to start fuzzing...\n");
             set_fast_reload_mode(false);
             set_fast_reload_path(snapshot_path);
             if (!skip_serialization) {
@@ -4670,7 +4670,7 @@ int main(int argc, char **argv, char **envp)
             fast_reload_init(GET_GLOBAL_STATE()->fast_reload_snapshot);
         } else {
             if (pre_snapshot_used) {
-                nyx_printf("[Qemu-Nyx]: preparing to create pre image...\n");
+                nyx_printf("Preparing to create pre image...\n");
                 set_fast_reload_pre_path(pre_snapshot_path);
                 set_fast_reload_pre_image();
             } else if (snapshot_used) {
@@ -4681,7 +4681,7 @@ int main(int argc, char **argv, char **envp)
                 if (load_mode) {
                     set_fast_reload_mode(true);
                     nyx_printf(
-                        "[Qemu-Nyx]: waiting for snapshot to start fuzzing...\n");
+                        "Waiting for snapshot to start fuzzing...\n");
                     fast_reload_create_from_file(get_fast_reload_snapshot(),
                                                  snapshot_path, false);
                     // cpu_synchronize_all_post_reset();
@@ -4690,7 +4690,7 @@ int main(int argc, char **argv, char **envp)
                     skip_init();
                     // GET_GLOBAL_STATE()->pt_trace_mode = false;
                 } else {
-                    nyx_printf("[Qemu-Nyx]: Booting VM to start fuzzing...\n");
+                    nyx_printf("Booting VM to start fuzzing...\n");
                     set_fast_reload_mode(false);
                 }
             }


### PR DESCRIPTION
- more flexible nyx_abort()
- replace fprintf(stderr) with macros leading to qemu logging facility

=> updated + ready for review.
=> not all fprintf() converted, see individual commit msg for detail.