### PR TITLE
fix req_stream_data_bulk() return size

### DIFF
--- a/nyx/hypercall/hypercall.h
+++ b/nyx/hypercall/hypercall.h
@@ -168,3 +168,9 @@ typedef struct kafl_dump_file_s {
     uint64_t bytes;
     uint8_t  append;
 } __attribute__((packed)) kafl_dump_file_t;
+
+typedef struct req_data_bulk_s {
+    char     file_name[256];
+    uint64_t num_addresses;
+    uint64_t addresses[479];
+} __attribute__((packed)) req_data_bulk_t;


### PR DESCRIPTION
Hypercall failed to handle the default case where 0 < ret_value < 4096. The handler keeps looping over num_addresses, returning a too large overall file size to the guest.

For a 4 byte test file, hget_bulk() would fetch + write 960 bytes.

Also moved struct definition to header + set __attribute__((packed)).