### PR TITLE
Allow multiple GET_HOST / SET_AGENT config calls

### DIFF
--- a/nyx/hypercall/configuration.c
+++ b/nyx/hypercall/configuration.c
@@ -16,10 +16,7 @@ void handle_hypercall_kafl_get_host_config(struct kvm_run *run,
         return;
     }
 
-    if (GET_GLOBAL_STATE()->get_host_config_done) {
-        nyx_abort((char *)"KVM_EXIT_KAFL_GET_HOST_CONFIG called twice...");
-        return;
-    }
+    nyx_trace();
 
     memset((void *)&config, 0, sizeof(host_config_t));
 
@@ -46,8 +43,7 @@ void handle_hypercall_kafl_set_agent_config(struct kvm_run *run,
     }
 
     if (GET_GLOBAL_STATE()->set_agent_config_done) {
-        nyx_abort((char *)"KVM_EXIT_KAFL_SET_AGENT_CONFIG called twice...");
-        return;
+        nyx_abort("SET_AGENT_CONFIG called twice.");
     }
 
     X86CPU      *cpux86 = X86_CPU(cpu);

--- a/nyx/hypercall/configuration.c
+++ b/nyx/hypercall/configuration.c
@@ -18,7 +18,7 @@ void handle_hypercall_kafl_get_host_config(struct kvm_run *run,
     }
 
     if (GET_GLOBAL_STATE()->get_host_config_done) {
-        nyx_trace();
+        nyx_debug("KVM_EXIT_KAFL_GET_HOST_CONFIG called again...");
     }
 
     memset((void *)&config, 0, sizeof(host_config_t));
@@ -46,7 +46,7 @@ void handle_hypercall_kafl_set_agent_config(struct kvm_run *run,
     }
 
     if (GET_GLOBAL_STATE()->set_agent_config_done) {
-        nyx_abort((char *)"KVM_EXIT_KAFL_SET_AGENT_CONFIG called twice...");
+        nyx_abort("KVM_EXIT_KAFL_SET_AGENT_CONFIG called twice...");
     }
 
     X86CPU      *cpux86 = X86_CPU(cpu);

--- a/nyx/hypercall/configuration.c
+++ b/nyx/hypercall/configuration.c
@@ -4,6 +4,7 @@
 #include "nyx/hypercall/configuration.h"
 #include "nyx/memory_access.h"
 #include "nyx/state/state.h"
+#include "nyx/debug.h"
 
 void handle_hypercall_kafl_get_host_config(struct kvm_run *run,
                                            CPUState       *cpu,
@@ -16,7 +17,9 @@ void handle_hypercall_kafl_get_host_config(struct kvm_run *run,
         return;
     }
 
-    nyx_trace();
+    if (GET_GLOBAL_STATE()->get_host_config_done) {
+        nyx_trace();
+    }
 
     memset((void *)&config, 0, sizeof(host_config_t));
 
@@ -43,7 +46,7 @@ void handle_hypercall_kafl_set_agent_config(struct kvm_run *run,
     }
 
     if (GET_GLOBAL_STATE()->set_agent_config_done) {
-        nyx_abort("SET_AGENT_CONFIG called twice.");
+        nyx_abort((char *)"KVM_EXIT_KAFL_SET_AGENT_CONFIG called twice...");
     }
 
     X86CPU      *cpux86 = X86_CPU(cpu);


### PR DESCRIPTION
Re #41: GET_HOST_CONFIG may be queried multiple times by tools like hpush, or combining htools with later loader/forkserver.

Calling GET_HOST multiple times does not seem to do anything. Similarly, calling the SET_AGENT_CONFIG multiple times does not seem to have any effect except that the latest config is being applied. Seems like a good feature.

We can keep a debug/info message in place so that users can spot if these are called multiple times. But I think that is best done by a general hypercall trace message?