### PR TITLE
remove duplicate warn/error strings

### DIFF
--- a/nyx/auxiliary_buffer.c
+++ b/nyx/auxiliary_buffer.c
@@ -257,7 +257,7 @@ void set_state_auxiliary_result_buffer(auxilary_buffer_t *auxilary_buffer,
     if (auxilary_buffer) {
         VOLATILE_WRITE_8(auxilary_buffer->result.state, state);
     } else {
-        nyx_error("WARNING: auxilary_buffer pointer is zero\n");
+        nyx_error("auxilary_buffer pointer is zero\n");
     }
 }
 

--- a/nyx/memory_access.c
+++ b/nyx/memory_access.c
@@ -1023,7 +1023,7 @@ uint64_t disassemble_at_rip(int fd, uint64_t address, CPUState *cpu, uint64_t cr
                       insn[i].mnemonic, insn[i].op_str);
         }
     } else {
-        nyx_error("ERROR in %s at %lx (cr3: %lx)\n", __func__, address, cr3);
+        nyx_error("nothing to decode at %s(%lx,%lx)\n", __func__, address, cr3);
     }
 
 

--- a/nyx/pt.c
+++ b/nyx/pt.c
@@ -116,10 +116,10 @@ void pt_dump(CPUState *cpu, int bytes)
                     libxdc_get_page_fault_addr(GET_GLOBAL_STATE()->decoder);
                 break;
             case decoder_unkown_packet:
-                nyx_warn("WARNING: libxdc_decode returned unknown_packet\n");
+                nyx_warn("libxdc_decode returned unknown_packet\n");
                 break;
             case decoder_error:
-                nyx_warn("WARNING: libxdc_decode returned decoder_error\n");
+                nyx_warn("libxdc_decode returned decoder_error\n");
                 break;
             }
         }


### PR DESCRIPTION
warn/err macro already puts this prefix.
`grep` tells me these are the last instances of duplicate labels (but you never know)