### PR TITLE
Reset PT trashed flag, fix setting `starved` bit

### DIFF
--- a/nyx/auxiliary_buffer.c
+++ b/nyx/auxiliary_buffer.c
@@ -208,6 +208,11 @@ void set_pt_overflow_auxiliary_result_buffer(auxilary_buffer_t *auxilary_buffer)
     VOLATILE_WRITE_8(auxilary_buffer->result.pt_overflow, 1);
 }
 
+void reset_pt_overflow_auxiliary_result_buffer(auxilary_buffer_t *auxilary_buffer)
+{
+    VOLATILE_WRITE_8(auxilary_buffer->result.pt_overflow, 0);
+}
+
 void set_exec_done_auxiliary_result_buffer(auxilary_buffer_t *auxilary_buffer,
                                            uint32_t           sec,
                                            uint32_t           usec,

--- a/nyx/auxiliary_buffer.h
+++ b/nyx/auxiliary_buffer.h
@@ -161,6 +161,7 @@ void set_asan_auxiliary_result_buffer(auxilary_buffer_t *auxilary_buffer);
 void set_timeout_auxiliary_result_buffer(auxilary_buffer_t *auxilary_buffer);
 void set_reload_auxiliary_result_buffer(auxilary_buffer_t *auxilary_buffer);
 void set_pt_overflow_auxiliary_result_buffer(auxilary_buffer_t *auxilary_buffer);
+void reset_pt_overflow_auxiliary_result_buffer(auxilary_buffer_t *auxilary_buffer);
 void set_exec_done_auxiliary_result_buffer(auxilary_buffer_t *auxilary_buffer,
                                            uint32_t           sec,
                                            uint32_t           usec,

--- a/nyx/synchronization.c
+++ b/nyx/synchronization.c
@@ -266,10 +266,7 @@ void synchronization_lock(void)
     check_auxiliary_config_buffer(GET_GLOBAL_STATE()->auxilary_buffer,
                                   &GET_GLOBAL_STATE()->shadow_config);
 
-    if (GET_GLOBAL_STATE()->starved == true)
-        set_success_auxiliary_result_buffer(GET_GLOBAL_STATE()->auxilary_buffer, 2);
-    else
-        set_success_auxiliary_result_buffer(GET_GLOBAL_STATE()->auxilary_buffer, 1);
+    set_success_auxiliary_result_buffer(GET_GLOBAL_STATE()->auxilary_buffer, 1);
     reset_pt_overflow_auxiliary_result_buffer(GET_GLOBAL_STATE()->auxilary_buffer);
 
     GET_GLOBAL_STATE()->pt_trace_size = 0;
@@ -427,6 +424,9 @@ void synchronization_disable_pt(CPUState *cpu)
                              GET_GLOBAL_STATE()->pt_trace_size);
     set_result_bb_coverage(GET_GLOBAL_STATE()->auxilary_buffer,
                            GET_GLOBAL_STATE()->bb_coverage);
+
+    if (GET_GLOBAL_STATE()->starved == true)
+        set_success_auxiliary_result_buffer(GET_GLOBAL_STATE()->auxilary_buffer, 2);
 
     in_fuzzing_loop = false;
 }

--- a/nyx/synchronization.c
+++ b/nyx/synchronization.c
@@ -220,10 +220,6 @@ void synchronization_lock(void)
     pthread_mutex_lock(&synchronization_lock_mutex);
     run_counter++;
 
-    if (qemu_get_cpu(0)->intel_pt_run_trashed) {
-        set_pt_overflow_auxiliary_result_buffer(GET_GLOBAL_STATE()->auxilary_buffer);
-    }
-
     long runtime_sec  = timer.config.tv_sec - timer.alarm.it_value.tv_sec;
     long runtime_usec = timer.config.tv_usec - timer.alarm.it_value.tv_usec;
 
@@ -240,6 +236,11 @@ void synchronization_lock(void)
 
     if (synchronization_check_page_not_found()) {
         set_success_auxiliary_result_buffer(GET_GLOBAL_STATE()->auxilary_buffer, 0);
+    }
+
+    if (qemu_get_cpu(0)->intel_pt_run_trashed) {
+        set_pt_overflow_auxiliary_result_buffer(GET_GLOBAL_STATE()->auxilary_buffer);
+        qemu_get_cpu(0)->intel_pt_run_trashed = false;
     }
 
     if (GET_GLOBAL_STATE()->dump_page) {
@@ -269,6 +270,7 @@ void synchronization_lock(void)
         set_success_auxiliary_result_buffer(GET_GLOBAL_STATE()->auxilary_buffer, 2);
     else
         set_success_auxiliary_result_buffer(GET_GLOBAL_STATE()->auxilary_buffer, 1);
+    reset_pt_overflow_auxiliary_result_buffer(GET_GLOBAL_STATE()->auxilary_buffer);
 
     GET_GLOBAL_STATE()->pt_trace_size = 0;
 }


### PR DESCRIPTION
Looking at PT dumps, I noticed that *all* executions are flagged at overflow but subsequent decode with libxdc/ptdump only flagged some of the traces. Turns out we should probably reset the overflow bit.

Also, I think the set/reset of starved bit was wrong. If I understand correctly, it was flagging the execution that followed the actual starved event. All of this sync functions and aux_buffer setting can probably use some cleanup..