### PR TITLE
Fix RAM offset translation

### DIFF
--- a/hw/i386/pc_piix.c
+++ b/hw/i386/pc_piix.c
@@ -61,6 +61,11 @@
 #include "migration/misc.h"
 #include "sysemu/numa.h"
 
+#ifdef QEMU_NYX
+#include "nyx/state/state.h"
+#include "nyx/mem_split.h"
+#endif
+
 #define MAX_IDE_BUS 2
 
 #ifdef CONFIG_IDE_ISA
@@ -147,9 +152,15 @@ static void pc_init1(MachineState *machine,
         if (machine->ram_size >= lowmem) {
             x86ms->above_4g_mem_size = machine->ram_size - lowmem;
             x86ms->below_4g_mem_size = lowmem;
+#ifdef QEMU_NYX
+            GET_GLOBAL_STATE()->mem_mapping_type = PC_PIIX_MEM_TYPE;
+#endif
         } else {
             x86ms->above_4g_mem_size = 0;
             x86ms->below_4g_mem_size = machine->ram_size;
+#ifdef QEMU_NYX
+            GET_GLOBAL_STATE()->mem_mapping_type = PC_PIIX_MEM_LOW_TYPE;
+#endif
         }
     }
 

--- a/hw/i386/pc_piix.c
+++ b/hw/i386/pc_piix.c
@@ -154,12 +154,16 @@ static void pc_init1(MachineState *machine,
             x86ms->below_4g_mem_size = lowmem;
 #ifdef QEMU_NYX
             GET_GLOBAL_STATE()->mem_mapping_type = PC_PIIX_MEM_TYPE;
+            GET_GLOBAL_STATE()->mem_mapping_low = lowmem;
+            GET_GLOBAL_STATE()->mem_mapping_high = 0x100000000;
 #endif
         } else {
             x86ms->above_4g_mem_size = 0;
             x86ms->below_4g_mem_size = machine->ram_size;
 #ifdef QEMU_NYX
-            GET_GLOBAL_STATE()->mem_mapping_type = PC_PIIX_MEM_LOW_TYPE;
+            GET_GLOBAL_STATE()->mem_mapping_type = PC_PIIX_MEM_TYPE;
+            GET_GLOBAL_STATE()->mem_mapping_low = lowmem;
+            GET_GLOBAL_STATE()->mem_mapping_high = 0;
 #endif
         }
     }

--- a/hw/i386/pc_q35.c
+++ b/hw/i386/pc_q35.c
@@ -150,14 +150,8 @@ static void pc_q35_init(MachineState *machine)
      */
     if (machine->ram_size >= 0xb0000000) {
         lowmem = 0x80000000;
-#ifdef QEMU_NYX
-        GET_GLOBAL_STATE()->mem_mapping_type = Q35_MEM_MEM_TYPE;
-#endif
     } else {
         lowmem = 0xb0000000;
-#ifdef QEMU_NYX
-        GET_GLOBAL_STATE()->mem_mapping_type = Q35_MEM_MEM_LOW_TYPE;
-#endif
     }
 
     /* Handle the machine opt max-ram-below-4g.  It is basically doing
@@ -181,9 +175,19 @@ static void pc_q35_init(MachineState *machine)
     if (machine->ram_size >= lowmem) {
         x86ms->above_4g_mem_size = machine->ram_size - lowmem;
         x86ms->below_4g_mem_size = lowmem;
+#ifdef QEMU_NYX
+        GET_GLOBAL_STATE()->mem_mapping_type = Q35_MEM_MEM_TYPE;
+        GET_GLOBAL_STATE()->mem_mapping_low = lowmem;
+        GET_GLOBAL_STATE()->mem_mapping_high = 0x100000000;
+#endif
     } else {
         x86ms->above_4g_mem_size = 0;
         x86ms->below_4g_mem_size = machine->ram_size;
+#ifdef QEMU_NYX
+        GET_GLOBAL_STATE()->mem_mapping_type = Q35_MEM_MEM_TYPE;
+        GET_GLOBAL_STATE()->mem_mapping_low = lowmem;
+        GET_GLOBAL_STATE()->mem_mapping_high = 0;
+#endif
     }
 
     if (xen_enabled()) {

--- a/hw/i386/pc_q35.c
+++ b/hw/i386/pc_q35.c
@@ -53,6 +53,11 @@
 #include "qapi/error.h"
 #include "qemu/error-report.h"
 #include "sysemu/numa.h"
+#ifdef QEMU_NYX
+#include "nyx/state/state.h"
+#include "nyx/mem_split.h"
+
+#endif
 
 /* ICH9 AHCI has 6 ports */
 #define MAX_SATA_PORTS     6
@@ -145,8 +150,14 @@ static void pc_q35_init(MachineState *machine)
      */
     if (machine->ram_size >= 0xb0000000) {
         lowmem = 0x80000000;
+#ifdef QEMU_NYX
+        GET_GLOBAL_STATE()->mem_mapping_type = Q35_MEM_MEM_TYPE;
+#endif
     } else {
         lowmem = 0xb0000000;
+#ifdef QEMU_NYX
+        GET_GLOBAL_STATE()->mem_mapping_type = Q35_MEM_MEM_LOW_TYPE;
+#endif
     }
 
     /* Handle the machine opt max-ram-below-4g.  It is basically doing

--- a/nyx/Makefile.objs
+++ b/nyx/Makefile.objs
@@ -33,5 +33,6 @@ hypercall/configuration.o \
 hypercall/debug.o \
 state/state.o \
 state/snapshot_state.o \
-pt.o
+pt.o \
+mem_split.o
 

--- a/nyx/debug.h
+++ b/nyx/debug.h
@@ -41,6 +41,14 @@
 #define nyx_warn(format, ...)   qemu_log(NYX_LOG_PREFIX "Warning: " format, ##__VA_ARGS__)
 #define nyx_trace(format, ...)  nyx_debug("=> %s\n", __func__)
 
+#define nyx_warn_once(format, ...)                      \
+    ({                                                  \
+        static bool _printed = false;                   \
+        if (_printed == false){                         \
+            _printed = true;                            \
+            nyx_warn(format, ##__VA_ARGS__);            \
+        }                                               \
+    })
 
 #ifdef ENABLE_BACKTRACES
 void qemu_backtrace(void);

--- a/nyx/hypercall/debug.c
+++ b/nyx/hypercall/debug.c
@@ -6,6 +6,7 @@
 
 #include "nyx/fast_vm_reload.h"
 #include "nyx/hypercall/debug.h"
+#include "nyx/mem_split.h"
 #include "nyx/memory_access.h"
 #include "nyx/state/state.h"
 #include "nyx/synchronization.h"

--- a/nyx/hypercall/debug.c
+++ b/nyx/hypercall/debug.c
@@ -6,9 +6,11 @@
 
 #include "nyx/fast_vm_reload.h"
 #include "nyx/hypercall/debug.h"
+#include "nyx/memory_access.h"
 #include "nyx/state/state.h"
 #include "nyx/synchronization.h"
 #include "qapi/qapi-commands-dump.h"
+#include "exec/ram_addr.h"
 
 #ifdef NYX_DEBUG
 #define NYX_ENABLE_DEBUG_HYPERCALLS
@@ -50,6 +52,61 @@ static void meassure_performance(void)
         print_time_diff(1000);
     }
     perf_counter++;
+}
+
+static void handle_hypercall_kafl_debug_virt_to_ram_offset(struct kvm_run *run,
+                                                        CPUState       *cpu,
+                                                        uint64_t        hypercall_arg)
+{
+    static bool once = true;
+    CPUX86State *env;
+    static uint64_t ram_block = 0;
+    RAMBlock *block;
+
+    if(once){
+        if (!fast_snapshot_exists(GET_GLOBAL_STATE()->reload_state,
+                                  REQUEST_ROOT_EXISTS))
+        {
+            request_fast_vm_reload(GET_GLOBAL_STATE()->reload_state,
+                                REQUEST_SAVE_SNAPSHOT_ROOT);
+        }
+
+        QLIST_FOREACH_RCU (block, &ram_list.blocks, next) {
+            if (!memcmp(block->idstr, "pc.ram", 6)) {
+
+                ram_block = (uint64_t)block->host;
+                break;
+            }
+        }
+
+        assert(ram_block != 0);
+
+        once = false;
+    }
+
+    kvm_arch_get_registers_fast(cpu);
+    env = &(X86_CPU(cpu))->env;
+
+    uint64_t virt_addr = hypercall_arg & ~0xFFF; 
+
+    uint64_t phys_addr = (hwaddr)get_paging_phys_addr(cpu, env->cr[3], virt_addr) & 0xFFFFFFFFFFFFF000ULL;
+    uint64_t phys_addr_ram_offset = address_to_ram_offset(phys_addr);
+
+    if(!(phys_addr_ram_offset < snapshot_page_blocklist_get_phys_area_size(get_fast_reload_snapshot()->blocklist))){
+
+        printf("virt: %lx\n", virt_addr);
+        printf("phys: %lx\n", phys_addr);
+        printf("ram_offset: %lx\n", phys_addr_ram_offset);
+        abort();
+    }
+
+    *((uint64_t*)(ram_block+phys_addr_ram_offset)) = virt_addr;
+
+    if(ram_offset_to_address(phys_addr_ram_offset) != phys_addr){
+        printf("phys: %lx\n", phys_addr);
+        printf("ram_offset_to_address(phys_addr_ram_offset): %lx\n", ram_offset_to_address(phys_addr_ram_offset));
+        abort();
+    }
 }
 
 void handle_hypercall_kafl_debug_tmp_snapshot(struct kvm_run *run,
@@ -105,7 +162,7 @@ void handle_hypercall_kafl_debug_tmp_snapshot(struct kvm_run *run,
                                    REQUEST_LOAD_SNAPSHOT_ROOT);
             break;
         }
-    case 6:
+    case 6: // kcore debug hypercall
         nyx_warn_once("%s: perform kcore_dump!\n", __func__);
         bool in_fuzzing_mode_state = GET_GLOBAL_STATE()->in_fuzzing_mode;
         GET_GLOBAL_STATE()->in_fuzzing_mode = true;        
@@ -115,6 +172,9 @@ void handle_hypercall_kafl_debug_tmp_snapshot(struct kvm_run *run,
             nyx_abort("(qmp_dump_guest_memory): %s\n", error_get_pretty(err));
         }
         GET_GLOBAL_STATE()->in_fuzzing_mode = in_fuzzing_mode_state;
+        break;
+    case 7: // virtual address to ramblock offset debug hypercall
+        handle_hypercall_kafl_debug_virt_to_ram_offset(run, cpu, hypercall_arg);
         break;
     default:
         abort();

--- a/nyx/mem_split.c
+++ b/nyx/mem_split.c
@@ -2,84 +2,40 @@
 #include "nyx/state/state.h"
 #include "nyx/mem_split.h"
 
-#define PC_PIIX_LOW_MEM_SPLIT_START 0xe0000000
-
-#define PC_PIIX_MEM_SPLIT_START 0x0C0000000
-#define PC_PIXX_MEM_SPLIT_END   0x100000000
-
-#define Q35_MEM_SPLIT_START 0x080000000
-#define Q35_MEM_SPLIT_END   0x100000000
-
-#define Q35_LOW_MEM_SPLIT_START 0x0b0000000
-
 bool is_mem_mapping_supported(MemSplitType type){
-    return type == PC_PIIX_MEM_LOW_TYPE || type == PC_PIIX_MEM_TYPE || type == Q35_MEM_MEM_LOW_TYPE || type == Q35_MEM_MEM_TYPE;
+    return GET_GLOBAL_STATE()->mem_mapping_type != MEM_SPLIT_TYPE_INVALID;
 }
 
 uint64_t get_mem_split_start(void){
-    switch(GET_GLOBAL_STATE()->mem_mapping_type){
-        case PC_PIIX_MEM_LOW_TYPE: 
-            return PC_PIIX_LOW_MEM_SPLIT_START;
-        case PC_PIIX_MEM_TYPE: 
-            return PC_PIIX_MEM_SPLIT_START;
-        case Q35_MEM_MEM_LOW_TYPE:
-            return Q35_LOW_MEM_SPLIT_START;
-        case Q35_MEM_MEM_TYPE:
-            return Q35_MEM_SPLIT_START;
-        default:
-            abort();
-    }
+    assert(is_mem_mapping_supported(GET_GLOBAL_STATE()->mem_mapping_type));
+    return GET_GLOBAL_STATE()->mem_mapping_low;
 }
 
 uint64_t get_mem_split_end(void){
-    switch(GET_GLOBAL_STATE()->mem_mapping_type){
-        case PC_PIIX_MEM_TYPE: 
-            return PC_PIXX_MEM_SPLIT_END;
-        case Q35_MEM_MEM_TYPE:
-            return Q35_MEM_SPLIT_END;
-        default:
-            abort();
-    }
+    assert(is_mem_mapping_supported(GET_GLOBAL_STATE()->mem_mapping_type));
+    assert(GET_GLOBAL_STATE()->mem_mapping_high != 0);
+    return GET_GLOBAL_STATE()->mem_mapping_high;
 }
 
 uint64_t address_to_ram_offset(uint64_t offset){
-    switch(GET_GLOBAL_STATE()->mem_mapping_type){
-        case PC_PIIX_MEM_LOW_TYPE:
-            if(offset >= PC_PIIX_LOW_MEM_SPLIT_START){
-                abort();
-            }
-            return offset;
-        case PC_PIIX_MEM_TYPE: 
-            return offset >= PC_PIXX_MEM_SPLIT_END ? (offset - PC_PIXX_MEM_SPLIT_END) + PC_PIIX_MEM_SPLIT_START : offset;
-        case Q35_MEM_MEM_TYPE:
-            return offset >= Q35_MEM_SPLIT_END ? (offset - Q35_MEM_SPLIT_END) + Q35_MEM_SPLIT_START : offset;
-        case Q35_MEM_MEM_LOW_TYPE:
-            if(offset >= Q35_LOW_MEM_SPLIT_START){
-                abort();
-            }
-            return offset;
-        default:
-            abort();
+    assert(is_mem_mapping_supported(GET_GLOBAL_STATE()->mem_mapping_type));
+    if(GET_GLOBAL_STATE()->mem_mapping_high == 0){
+        assert(offset <= GET_GLOBAL_STATE()->mem_mapping_low);
+        return offset;
+    }
+    else{
+        return offset >= GET_GLOBAL_STATE()->mem_mapping_high ? (offset - GET_GLOBAL_STATE()->mem_mapping_high) + GET_GLOBAL_STATE()->mem_mapping_low : offset;
     }
 }
 
 uint64_t ram_offset_to_address(uint64_t offset){
-    switch(GET_GLOBAL_STATE()->mem_mapping_type){
-        case PC_PIIX_MEM_LOW_TYPE:
-            if(offset >= PC_PIIX_LOW_MEM_SPLIT_START){
-                abort();
-            }
-            return offset;
-        case PC_PIIX_MEM_TYPE: 
-            return offset >= PC_PIIX_MEM_SPLIT_START ? (offset - PC_PIIX_MEM_SPLIT_START) + PC_PIXX_MEM_SPLIT_END : offset;;
-        case Q35_MEM_MEM_TYPE:
-            return offset >= Q35_MEM_SPLIT_START ? (offset - Q35_MEM_SPLIT_START) + Q35_MEM_SPLIT_END : offset;
-        case Q35_MEM_MEM_LOW_TYPE:
-            if(offset >= Q35_LOW_MEM_SPLIT_START){
-                abort();
-            }
-            return offset;
-        default:
-            abort();
+
+    assert(is_mem_mapping_supported(GET_GLOBAL_STATE()->mem_mapping_type));
+    if(GET_GLOBAL_STATE()->mem_mapping_high == 0){
+        assert(offset <= GET_GLOBAL_STATE()->mem_mapping_low);
+        return offset;
+    }
+    else{
+        return offset >= GET_GLOBAL_STATE()->mem_mapping_low ? (offset - GET_GLOBAL_STATE()->mem_mapping_low) + GET_GLOBAL_STATE()->mem_mapping_high : offset;
     }
 }

--- a/nyx/mem_split.c
+++ b/nyx/mem_split.c
@@ -1,0 +1,85 @@
+#include "qemu/osdep.h"
+#include "nyx/state/state.h"
+#include "nyx/mem_split.h"
+
+#define PC_PIIX_LOW_MEM_SPLIT_START 0xe0000000
+
+#define PC_PIIX_MEM_SPLIT_START 0x0C0000000
+#define PC_PIXX_MEM_SPLIT_END   0x100000000
+
+#define Q35_MEM_SPLIT_START 0x080000000
+#define Q35_MEM_SPLIT_END   0x100000000
+
+#define Q35_LOW_MEM_SPLIT_START 0x0b0000000
+
+bool is_mem_mapping_supported(MemSplitType type){
+    return type == PC_PIIX_MEM_LOW_TYPE || type == PC_PIIX_MEM_TYPE || type == Q35_MEM_MEM_LOW_TYPE || type == Q35_MEM_MEM_TYPE;
+}
+
+uint64_t get_mem_split_start(void){
+    switch(GET_GLOBAL_STATE()->mem_mapping_type){
+        case PC_PIIX_MEM_LOW_TYPE: 
+            return PC_PIIX_LOW_MEM_SPLIT_START;
+        case PC_PIIX_MEM_TYPE: 
+            return PC_PIIX_MEM_SPLIT_START;
+        case Q35_MEM_MEM_LOW_TYPE:
+            return Q35_LOW_MEM_SPLIT_START;
+        case Q35_MEM_MEM_TYPE:
+            return Q35_MEM_SPLIT_START;
+        default:
+            abort();
+    }
+}
+
+uint64_t get_mem_split_end(void){
+    switch(GET_GLOBAL_STATE()->mem_mapping_type){
+        case PC_PIIX_MEM_TYPE: 
+            return PC_PIXX_MEM_SPLIT_END;
+        case Q35_MEM_MEM_TYPE:
+            return Q35_MEM_SPLIT_END;
+        default:
+            abort();
+    }
+}
+
+uint64_t address_to_ram_offset(uint64_t offset){
+    switch(GET_GLOBAL_STATE()->mem_mapping_type){
+        case PC_PIIX_MEM_LOW_TYPE:
+            if(offset >= PC_PIIX_LOW_MEM_SPLIT_START){
+                abort();
+            }
+            return offset;
+        case PC_PIIX_MEM_TYPE: 
+            return offset >= PC_PIXX_MEM_SPLIT_END ? (offset - PC_PIXX_MEM_SPLIT_END) + PC_PIIX_MEM_SPLIT_START : offset;
+        case Q35_MEM_MEM_TYPE:
+            return offset >= Q35_MEM_SPLIT_END ? (offset - Q35_MEM_SPLIT_END) + Q35_MEM_SPLIT_START : offset;
+        case Q35_MEM_MEM_LOW_TYPE:
+            if(offset >= Q35_LOW_MEM_SPLIT_START){
+                abort();
+            }
+            return offset;
+        default:
+            abort();
+    }
+}
+
+uint64_t ram_offset_to_address(uint64_t offset){
+    switch(GET_GLOBAL_STATE()->mem_mapping_type){
+        case PC_PIIX_MEM_LOW_TYPE:
+            if(offset >= PC_PIIX_LOW_MEM_SPLIT_START){
+                abort();
+            }
+            return offset;
+        case PC_PIIX_MEM_TYPE: 
+            return offset >= PC_PIIX_MEM_SPLIT_START ? (offset - PC_PIIX_MEM_SPLIT_START) + PC_PIXX_MEM_SPLIT_END : offset;;
+        case Q35_MEM_MEM_TYPE:
+            return offset >= Q35_MEM_SPLIT_START ? (offset - Q35_MEM_SPLIT_START) + Q35_MEM_SPLIT_END : offset;
+        case Q35_MEM_MEM_LOW_TYPE:
+            if(offset >= Q35_LOW_MEM_SPLIT_START){
+                abort();
+            }
+            return offset;
+        default:
+            abort();
+    }
+}

--- a/nyx/mem_split.h
+++ b/nyx/mem_split.h
@@ -6,9 +6,7 @@
 
 typedef enum MemSplitType {
     MEM_SPLIT_TYPE_INVALID,
-    PC_PIIX_MEM_LOW_TYPE,
     PC_PIIX_MEM_TYPE,
-    Q35_MEM_MEM_LOW_TYPE,
     Q35_MEM_MEM_TYPE,
 } MemSplitType;
 

--- a/nyx/mem_split.h
+++ b/nyx/mem_split.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "nyx/types.h"
+#include "stdlib.h"
+#include "stdint.h"
+
+typedef enum MemSplitType {
+    MEM_SPLIT_TYPE_INVALID,
+    PC_PIIX_MEM_LOW_TYPE,
+    PC_PIIX_MEM_TYPE,
+    Q35_MEM_MEM_LOW_TYPE,
+    Q35_MEM_MEM_TYPE,
+} MemSplitType;
+
+
+bool is_mem_mapping_supported(MemSplitType type);
+uint64_t get_mem_split_start(void);
+uint64_t get_mem_split_end(void);
+
+uint64_t address_to_ram_offset(uint64_t offset);
+uint64_t ram_offset_to_address(uint64_t offset);

--- a/nyx/memory_access.c
+++ b/nyx/memory_access.c
@@ -34,6 +34,7 @@ along with QEMU-PT.  If not, see <http://www.gnu.org/licenses/>.
 #include "nyx/helpers.h"
 #include "nyx/hypercall/hypercall.h"
 #include "nyx/state/state.h"
+#include "nyx/mem_split.h"
 
 #define INVALID_ADDRESS 0xFFFFFFFFFFFFFFFFULL
 

--- a/nyx/memory_access.h
+++ b/nyx/memory_access.h
@@ -27,14 +27,6 @@ along with QEMU-PT.  If not, see <http://www.gnu.org/licenses/>.
 #include "nyx/types.h"
 #include <linux/kvm.h>
 
-#define MEM_SPLIT_START 0x0C0000000
-#define MEM_SPLIT_END   0x100000000
-
-/* i386 pc_piix low_mem address translation */
-#define address_to_ram_offset(offset) \
-    (offset >= MEM_SPLIT_END ? (offset - MEM_SPLIT_END) + MEM_SPLIT_START : offset)
-#define ram_offset_to_address(offset) \
-    (offset >= MEM_SPLIT_START ? (offset - MEM_SPLIT_START) + MEM_SPLIT_END : offset)
 
 mem_mode_t get_current_mem_mode(CPUState *cpu);
 

--- a/nyx/snapshot/helper.c
+++ b/nyx/snapshot/helper.c
@@ -20,7 +20,9 @@ uint64_t get_ram_size(void)
     RAMBlock *block;
     uint64_t  guest_ram_size = 0;
     QLIST_FOREACH_RCU (block, &ram_list.blocks, next) {
-        guest_ram_size += block->used_length;
+        if(!strcmp(block->idstr, "pc.ram")){
+            guest_ram_size += block->used_length;
+        }
 #ifdef DEBUG_NYX_SNAPSHOT_HELPER
         printf("Block: %s (%lx)\n", block->idstr, block->used_length);
 #endif

--- a/nyx/snapshot/memory/block_list.c
+++ b/nyx/snapshot/memory/block_list.c
@@ -16,6 +16,9 @@
 
 // #define DEBUG_NYX_SNAPSHOT_PAGE_BLOCKLIST
 
+uint64_t snapshot_page_blocklist_get_phys_area_size(snapshot_page_blocklist_t *self){
+    return self->phys_area_size;
+}
 
 snapshot_page_blocklist_t *snapshot_page_blocklist_init(void)
 {

--- a/nyx/snapshot/memory/block_list.c
+++ b/nyx/snapshot/memory/block_list.c
@@ -11,6 +11,7 @@
 #include "nyx/snapshot/helper.h"
 #include "nyx/snapshot/memory/block_list.h"
 #include "nyx/snapshot/memory/shadow_memory.h"
+#include "nyx/mem_split.h"
 
 #define REALLOC_SIZE 0x8000
 
@@ -25,16 +26,16 @@ snapshot_page_blocklist_t *snapshot_page_blocklist_init(void)
     snapshot_page_blocklist_t *self = malloc(sizeof(snapshot_page_blocklist_t));
 
     uint64_t ram_size    = get_ram_size();
-    self->phys_area_size = ram_size <= MEM_SPLIT_START ?
+    self->phys_area_size = ram_size <= get_mem_split_start() ?
                                ram_size :
-                               ram_size + (MEM_SPLIT_END - MEM_SPLIT_START);
+                               ram_size + (get_mem_split_end() - get_mem_split_start());
 
     self->phys_bitmap = malloc(BITMAP_SIZE(self->phys_area_size));
     memset(self->phys_bitmap, 0x0, BITMAP_SIZE(self->phys_area_size));
 
-    if (ram_size > MEM_SPLIT_START) {
-        memset(self->phys_bitmap + BITMAP_SIZE(MEM_SPLIT_START), 0xff,
-               BITMAP_SIZE((MEM_SPLIT_END - MEM_SPLIT_START)));
+    if (ram_size > get_mem_split_start()) {
+        memset(self->phys_bitmap + BITMAP_SIZE(get_mem_split_start()), 0xff,
+               BITMAP_SIZE((get_mem_split_end() - get_mem_split_start())));
     }
 
     self->pages_num  = 0;

--- a/nyx/snapshot/memory/block_list.h
+++ b/nyx/snapshot/memory/block_list.h
@@ -32,3 +32,7 @@ static inline bool snapshot_page_blocklist_check_phys_addr(
 }
 
 snapshot_page_blocklist_t *snapshot_page_blocklist_init(void);
+
+#ifdef NYX_DEBUG
+uint64_t snapshot_page_blocklist_get_phys_area_size(snapshot_page_blocklist_t *self);
+#endif

--- a/nyx/snapshot/memory/nyx_fdl_user.c
+++ b/nyx/snapshot/memory/nyx_fdl_user.c
@@ -13,6 +13,7 @@
 #include "nyx/snapshot/helper.h"
 #include "nyx/snapshot/memory/nyx_fdl_user.h"
 #include "nyx/snapshot/memory/shadow_memory.h"
+#include "nyx/mem_split.h"
 
 /* debug option */
 // #define DEBUG_USER_FDL

--- a/nyx/snapshot/memory/shadow_memory.c
+++ b/nyx/snapshot/memory/shadow_memory.c
@@ -13,6 +13,7 @@
 
 #include "nyx/snapshot/helper.h"
 #include "nyx/snapshot/memory/shadow_memory.h"
+#include "nyx/mem_split.h"
 
 typedef struct fast_reload_dump_head_s {
     uint32_t shadow_memory_regions;
@@ -95,10 +96,10 @@ shadow_memory_t *shadow_memory_init(void)
     for (uint8_t i = 0; i < regions_num; i++) {
         block = block_array[i];
         if (!block->mr->readonly) {
-            if (self->ram_regions_num == 0 && block->used_length >= MEM_SPLIT_START) {
+            if (self->ram_regions_num == 0 && block->used_length >= get_mem_split_start()) {
                 self->ram_regions[self->ram_regions_num].ram_region = i;
                 self->ram_regions[self->ram_regions_num].base = block->mr->addr;
-                self->ram_regions[self->ram_regions_num].size = MEM_SPLIT_START;
+                self->ram_regions[self->ram_regions_num].size = get_mem_split_start();
                 self->ram_regions[self->ram_regions_num].offset =
                     snapshot_ptr_offset_array[i] - snapshot_ptr_offset_array[0];
                 self->ram_regions[self->ram_regions_num].host_region_ptr = block->host;
@@ -113,16 +114,14 @@ shadow_memory_t *shadow_memory_init(void)
                 self->ram_regions_num++;
 
                 self->ram_regions[self->ram_regions_num].ram_region = i;
-                self->ram_regions[self->ram_regions_num].base =
-MEM_SPLIT_END
-;
-self->ram_regions[self->ram_regions_num].size = block->used_length - MEM_SPLIT_START;
+                self->ram_regions[self->ram_regions_num].base = get_mem_split_end();
+self->ram_regions[self->ram_regions_num].size = block->used_length - get_mem_split_start();
 self->ram_regions[self->ram_regions_num].offset =
-    (snapshot_ptr_offset_array[i] + MEM_SPLIT_START) - snapshot_ptr_offset_array[0];
+    (snapshot_ptr_offset_array[i] + get_mem_split_start()) - snapshot_ptr_offset_array[0];
 self->ram_regions[self->ram_regions_num].host_region_ptr =
-    block->host + MEM_SPLIT_START;
+    block->host + get_mem_split_start();
 self->ram_regions[self->ram_regions_num].snapshot_region_ptr =
-    snapshot_ptr_offset_array[i] + MEM_SPLIT_START;
+    snapshot_ptr_offset_array[i] + get_mem_split_start();
 self->ram_regions[self->ram_regions_num].idstr = malloc(strlen(block->idstr) + 1);
 memset(self->ram_regions[self->ram_regions_num].idstr, 0, strlen(block->idstr) + 1);
 strcpy(self->ram_regions[self->ram_regions_num].idstr, block->idstr);
@@ -169,7 +168,7 @@ shadow_memory_t *shadow_memory_init_from_snapshot(const char *snapshot_folder,
     /* count number of ram regions */
     QLIST_FOREACH_RCU (block, &ram_list.blocks, next) {
         if (!block->mr->readonly) {
-            if (self->ram_regions_num == 0 && block->used_length >= MEM_SPLIT_START) {
+            if (self->ram_regions_num == 0 && block->used_length >= get_mem_split_start()) {
                 self->ram_regions_num++;
             }
             self->ram_regions_num++;
@@ -240,10 +239,10 @@ shadow_memory_t *shadow_memory_init_from_snapshot(const char *snapshot_folder,
     for (uint8_t i = 0; i < regions_num; i++) {
         block = block_array[i];
         if (!block->mr->readonly) {
-            if (self->ram_regions_num == 0 && block->used_length >= MEM_SPLIT_START) {
+            if (self->ram_regions_num == 0 && block->used_length >= get_mem_split_start()) {
                 self->ram_regions[self->ram_regions_num].ram_region = i;
                 self->ram_regions[self->ram_regions_num].base = block->mr->addr;
-                self->ram_regions[self->ram_regions_num].size = MEM_SPLIT_START;
+                self->ram_regions[self->ram_regions_num].size = get_mem_split_start();
                 self->ram_regions[self->ram_regions_num].offset =
                     snapshot_ptr_offset_array[i] - snapshot_ptr_offset_array[0];
                 self->ram_regions[self->ram_regions_num].host_region_ptr = block->host;
@@ -258,16 +257,14 @@ shadow_memory_t *shadow_memory_init_from_snapshot(const char *snapshot_folder,
                 self->ram_regions_num++;
 
                 self->ram_regions[self->ram_regions_num].ram_region = i;
-                self->ram_regions[self->ram_regions_num].base =
-MEM_SPLIT_END
-;
-self->ram_regions[self->ram_regions_num].size = block->used_length - MEM_SPLIT_START;
+                self->ram_regions[self->ram_regions_num].base = get_mem_split_end();
+self->ram_regions[self->ram_regions_num].size = block->used_length - get_mem_split_start();
 self->ram_regions[self->ram_regions_num].offset =
-    (snapshot_ptr_offset_array[i] + MEM_SPLIT_START) - snapshot_ptr_offset_array[0];
+    (snapshot_ptr_offset_array[i] + get_mem_split_start()) - snapshot_ptr_offset_array[0];
 self->ram_regions[self->ram_regions_num].host_region_ptr =
-    block->host + MEM_SPLIT_START;
+    block->host + get_mem_split_start();
 self->ram_regions[self->ram_regions_num].snapshot_region_ptr =
-    snapshot_ptr_offset_array[i] + MEM_SPLIT_START;
+    snapshot_ptr_offset_array[i] + get_mem_split_start();
 self->ram_regions[self->ram_regions_num].idstr = malloc(strlen(block->idstr) + 1);
 memset(self->ram_regions[self->ram_regions_num].idstr, 0, strlen(block->idstr) + 1);
 strcpy(self->ram_regions[self->ram_regions_num].idstr, block->idstr);

--- a/nyx/state/state.c
+++ b/nyx/state/state.c
@@ -117,6 +117,8 @@ void state_init_global(void)
     global_state.get_host_config_done  = false;
     global_state.set_agent_config_done = false;
 
+    global_state.mem_mapping_type = MEM_SPLIT_TYPE_INVALID;
+
     global_state.sharedir = sharedir_new();
 
 

--- a/nyx/state/state.c
+++ b/nyx/state/state.c
@@ -120,7 +120,8 @@ void state_init_global(void)
     global_state.mem_mapping_type = MEM_SPLIT_TYPE_INVALID;
 
     global_state.sharedir = sharedir_new();
-
+    global_state.mem_mapping_low = 0;
+    global_state.mem_mapping_high = 0;
 
     global_state.shared_bitmap_fd        = 0;
     global_state.shared_bitmap_size      = 0;

--- a/nyx/state/state.h
+++ b/nyx/state/state.h
@@ -30,6 +30,7 @@ along with QEMU-PT.  If not, see <http://www.gnu.org/licenses/>.
 #include "nyx/sharedir.h"
 #include "nyx/synchronization.h"
 #include "nyx/types.h"
+#include "nyx/mem_split.h"
 
 #include <libxdc.h>
 
@@ -136,6 +137,8 @@ typedef struct qemu_nyx_state_s {
 
     bool get_host_config_done;
     bool set_agent_config_done;
+
+    MemSplitType mem_mapping_type;
 
     /* capabilites */
     uint8_t  cap_timeout_detection;

--- a/nyx/state/state.h
+++ b/nyx/state/state.h
@@ -139,6 +139,8 @@ typedef struct qemu_nyx_state_s {
     bool set_agent_config_done;
 
     MemSplitType mem_mapping_type;
+    uint64_t mem_mapping_low;
+    uint64_t mem_mapping_high;
 
     /* capabilites */
     uint8_t  cap_timeout_detection;

--- a/vl.c
+++ b/vl.c
@@ -143,6 +143,7 @@ int main(int argc, char **argv)
 #include "nyx/pt.h"
 #include "nyx/state/state.h"
 #include "nyx/synchronization.h"
+#include "nyx/mem_split.h"
 // clang-format off
 #endif
 
@@ -4588,6 +4589,11 @@ int main(int argc, char **argv, char **envp)
 
 #ifdef QEMU_NYX
     // clang-format on
+    if(is_mem_mapping_supported(GET_GLOBAL_STATE()->mem_mapping_type) == false){
+        nyx_error("Unsupported memory mapping type (only q35 and pc_piix are supported)\n");
+        exit(1);
+    }
+
     fast_reload_init(GET_GLOBAL_STATE()->fast_reload_snapshot);
 
     if (fast_vm_reload) {


### PR DESCRIPTION
The translation of physical guest addresses to host ram offsets was completely broken and is hopefully fixed with this PR.

The incorrect address translation led to interesting bugs that were difficult to reproduce (such as https://github.com/IntelLabs/kAFL/issues/141). However, I suspect such errors only occur when memory is read from the snapshot, which relies on ram offset helper functions. Nevertheless, since the translation is incorrect, wrong data might be fetched from the snapshot.  

We should probably do some more field testing, before we merge this PR, but it looks like that everything works as expected at this point.  

The following agent program can be used to test the address translation (since the agent runs in userland, not the entire guest memory can be allocated and tested):

```C
#define _GNU_SOURCE

#include <stdio.h>
#include <stdlib.h>
#include <stdint.h>
#include <sys/mman.h>
#include <unistd.h>
#include <sys/resource.h>
#include <sys/mman.h>
#include "../nyx.h"

int main(int argc, char** argv){ 
    uint64_t pages = sysconf(_SC_PHYS_PAGES);
    uint64_t free_pages = sysconf(_SC_AVPHYS_PAGES);
    uint64_t page_size = sysconf(_SC_PAGE_SIZE);
    uint64_t total_memory = pages * page_size;
    uint64_t free_memory = free_pages * page_size;

    printf("[*] _SC_PHYS_PAGES:   %ld\n", pages);
    printf("[*] _SC_AVPHYS_PAGES: %ld\n", free_pages);
    printf("[*] _SC_PAGE_SIZE:    %ld\n", total_memory);

    /* we leave some memory free in order to not trigger the OOM killer */
    if (free_memory >= (1024*1024*170)){
        free_memory -= (1024*1024*170);
    }

    free_memory &= ~0xFFFULL;

    printf("[*] free_memory total size: 0x%lx\n", free_memory);

    void* memory = mmap((void*)NULL, free_memory, PROT_READ | PROT_WRITE, MAP_ANON | MAP_SHARED, -1, 0);
    if (memory == (void*)-1){
        perror("Error ");
    }

    printf("[*] mmap mapping at: %p\n", memory);

    mlockall(MCL_CURRENT);

    memset(memory, 0xff, free_memory);

    mlockall(MCL_CURRENT);

    for (uint64_t page = 0; page < free_memory; page += page_size){
        kAFL_hypercall(HYPERCALL_KAFL_DEBUG_TMP_SNAPSHOT, (uint64_t)(memory+page) | 7 );

        if(*((uint64_t*)(memory+page)) != (uint64_t)memory+page){
            printf("[!] ERROR: 0x%lx\n", *((uint64_t*)(memory+page)));
            printf("[!] EXPECTED: %p\n", memory+page);
            exit(1);
        }
    }

    printf("[*] all tests passed!\n");

    return 0;
}

```

The following test cases resulted in either an incorrect translation or QEMU-Nyx crashes. With this PR, all tests should now pass.

```bash
# PC_PIIX (RAM sizes between 3072-3583M are incorrectly handled)

../qemu-nyx/x86_64-softmmu/qemu-system-x86_64 -kernel bzImage-linux-4.15-rc7 -initrd init_debug_shell.cpio.gz -serial mon:stdio -enable-kvm -k de -m 3583 -machine kAFL64-v1 -net none  -append "root=/dev/sda console=ttyS0" -nographic

# Q35 (RAM sizes below 2815M are also incorrectly handled) 

../qemu-nyx/x86_64-softmmu/qemu-system-x86_64 -kernel bzImage-linux-4.15-rc7 -initrd init_debug_shell.cpio.gz -serial mon:stdio -enable-kvm -k de -m 2815 -machine kAFL64 -net none  -append "root=/dev/sda console=ttyS0" -nographic


# Q35 (address translation for RAM size above 4GB is also broken) 

../qemu-nyx/x86_64-softmmu/qemu-system-x86_64 -kernel bzImage-linux-4.15-rc7 -initrd init_debug_shell.cpio.gz -serial mon:stdio -enable-kvm -k de -m 7500 -machine kAFL64 -net none  -append "root=/dev/sda console=ttyS0" -nographic

# The address translation will also fail If the memory split is manually set (fixed with this PR)

../qemu-nyx/x86_64-softmmu/qemu-system-x86_64 -kernel bzImage-linux-4.15-rc7 -initrd init_debug_shell.cpio.gz -serial mon:stdio -enable-kvm -k de -M q35,max-ram-below-4g=2G -m 4G -net none  -append "root=/dev/sda console=ttyS0" -nographic

../qemu-nyx/x86_64-softmmu/qemu-system-x86_64 -kernel bzImage-linux-4.15-rc7 -initrd init_debug_shell.cpio.gz -serial mon:stdio -enable-kvm -k de -M pc,max-ram-below-4g=2G -m 4G -net none  -append "root=/dev/sda console=ttyS0" -nographic
```