### PR TITLE
Split FDL and PT mode

### DIFF
--- a/compile_qemu_nyx.sh
+++ b/compile_qemu_nyx.sh
@@ -30,6 +30,7 @@ error()
   echo "Available compile options: "
   echo " -  dynamic        dynamically link libxdc and capstone4"
   echo " -  static         statically link libxdc and capstone4"
+  echo " -  full_static    compile a full static QEMU build"
   echo " -  lto            enable static linking and LTO (up to 10% better performance)"
   echo " -  debug          enable debug and ASAN options"
   echo " -  debug_static   enable debug, ASAN and static linking"
@@ -40,7 +41,7 @@ error()
 compile_libraries()
 {
   case $1 in
-    "debug_static"|"static"|"lto")
+    "debug_static"|"static"|"full_static"|"lto")
       echo "[!] Compiling capstone4..."
       make -C $CAPSTONE_ROOT -j $(nproc)
 
@@ -55,7 +56,7 @@ configure_qemu()
   QEMU_CONFIGURE="./configure --target-list=x86_64-softmmu --disable-docs --disable-gtk --disable-werror --disable-capstone --disable-libssh --disable-tools"
 
   case $1 in
-    "debug_static"|"static"|"lto")
+    "debug_static"|"static"|"full_static"|"lto")
       export LIBS="-L$CAPSTONE_ROOT -L$LIBXDC_ROOT/ $LIBS"
       export QEMU_CFLAGS="-I$CAPSTONE_ROOT/include/ -I$LIBXDC_ROOT/ $QEMU_CFLAGS"
       ;;
@@ -75,6 +76,9 @@ configure_qemu()
       ;;
     "static")
       $QEMU_CONFIGURE --enable-nyx --enable-nyx-static
+      ;;
+    "full_static")
+      $QEMU_CONFIGURE --enable-nyx --enable-nyx-static --static --disable-xkbcommon --disable-usb-redir --disable-smartcard --disable-slirp --disable-opengl --audio-drv-list= --disable-libusb --disable-rdma --disable-libiscsi
       ;;
     "lto")
       $QEMU_CONFIGURE --enable-nyx --enable-nyx-static --enable-nyx-flto
@@ -97,7 +101,7 @@ if [ "$#" -ne 1 ] ; then
 fi
 
 case $1 in
-    "dynamic"|"debug"|"debug_static"|"static"|"lto")
+    "dynamic"|"debug"|"debug_static"|"static"|"full_static"|"lto")
       ;;
     *)
       error

--- a/compile_qemu_nyx.sh
+++ b/compile_qemu_nyx.sh
@@ -78,7 +78,7 @@ configure_qemu()
       $QEMU_CONFIGURE --enable-nyx --enable-nyx-static
       ;;
     "full_static")
-      $QEMU_CONFIGURE --enable-nyx --enable-nyx-static --static --disable-xkbcommon --disable-usb-redir --disable-smartcard --disable-slirp --disable-opengl --audio-drv-list= --disable-libusb --disable-rdma --disable-libiscsi
+      $QEMU_CONFIGURE --enable-nyx --enable-nyx-static --static --enable-slirp=git --disable-xkbcommon --disable-usb-redir --disable-smartcard --disable-opengl --audio-drv-list= --disable-libusb --disable-rdma --disable-libiscsi
       ;;
     "lto")
       $QEMU_CONFIGURE --enable-nyx --enable-nyx-static --enable-nyx-flto

--- a/nyx/fast_vm_reload_sync.c
+++ b/nyx/fast_vm_reload_sync.c
@@ -25,19 +25,14 @@ extern int load_snapshot(const char *name, Error **errp);
 
 static void adjust_rip(CPUX86State *env, fast_reload_t *snapshot)
 {
-    switch (fast_reload_get_mode(snapshot)) {
-    case RELOAD_MEMORY_MODE_DEBUG:
-    case RELOAD_MEMORY_MODE_DEBUG_QUIET:
-        env->eip -= 1; /* out */
-        break;
-    case RELOAD_MEMORY_MODE_FDL:
-    case RELOAD_MEMORY_MODE_FDL_DEBUG:
+    /* PT mode relies on a custom kernel which uses 'vmcall' hypercalls instead of
+     * vmware-backdoor based hypercalls (via 'out' instructions). 
+     */
+    if (GET_GLOBAL_STATE()->nyx_pt == true){
         env->eip -= 3; /* vmcall */
-        break;
-    case RELOAD_MEMORY_MODE_DIRTY_RING:
-    case RELOAD_MEMORY_MODE_DIRTY_RING_DEBUG:
+    }
+    else{
         env->eip -= 1; /* out */
-        break;
     }
 }
 

--- a/nyx/hypercall/configuration.c
+++ b/nyx/hypercall/configuration.c
@@ -70,7 +70,7 @@ void handle_hypercall_kafl_set_agent_config(struct kvm_run *run,
         GET_GLOBAL_STATE()->cap_compile_time_tracing = config.agent_tracing;
 
         if (!GET_GLOBAL_STATE()->cap_compile_time_tracing &&
-            !GET_GLOBAL_STATE()->nyx_fdl)
+            !GET_GLOBAL_STATE()->nyx_pt)
         {
             nyx_abort("No Intel PT support on this KVM build and no "
                       "compile-time instrumentation enabled in the target\n");

--- a/nyx/state/state.c
+++ b/nyx/state/state.c
@@ -45,7 +45,7 @@ void state_init_global(void)
     /* safety first */
     assert(libxdc_get_release_version() == LIBXDC_RELEASE_VERSION_REQUIRED);
 
-    global_state.nyx_fdl = false;
+    global_state.nyx_pt = false;
 
     global_state.workdir_path = NULL;
     global_state.worker_id    = 0xffff;

--- a/nyx/state/state.h
+++ b/nyx/state/state.h
@@ -37,8 +37,8 @@ along with QEMU-PT.  If not, see <http://www.gnu.org/licenses/>.
 #define INTEL_PT_MAX_RANGES 4
 
 typedef struct qemu_nyx_state_s {
-    /* set if FDL backend is used (required to perform some additional runtime tests) */
-    bool nyx_fdl;
+    /* set if PT mode is supported */
+    bool nyx_pt;
 
     char    *workdir_path;
     uint32_t worker_id;

--- a/target/i386/cpu.c
+++ b/target/i386/cpu.c
@@ -4484,11 +4484,11 @@ static void x86_cpuid_set_model_id(Object *obj, const char *model_id,
         model_id = "";
     }
 #ifdef QEMU_NYX
-    if(strncmp(model_id, NYX_PT_CPU_MODEL, strlen(NYX_PT_CPU_MODEL)) == 0 && GET_GLOBAL_STATE()->nyx_fdl == false){
+    if(strncmp(model_id, NYX_PT_CPU_MODEL, strlen(NYX_PT_CPU_MODEL)) == 0 && GET_GLOBAL_STATE()->nyx_pt == false){
         fprintf(stderr, "[QEMU-Nyx] Warning: Attempt to use unsupported CPU model (PT) without KVM-PT (Hint: use '-cpu kAFL64-Hypervisor-v2' instead)\n");
         model_id = NYX_NO_PT_CPU_MODEL;
     }
-    if(strncmp(model_id, NYX_NO_PT_CPU_MODEL, strlen(NYX_NO_PT_CPU_MODEL)) == 0 && GET_GLOBAL_STATE()->nyx_fdl == true){
+    if(strncmp(model_id, NYX_NO_PT_CPU_MODEL, strlen(NYX_NO_PT_CPU_MODEL)) == 0 && GET_GLOBAL_STATE()->nyx_pt == true){
         fprintf(stderr, "[QEMU-Nyx] Error: Attempt to use unsupported CPU model (NO-PT) with KVM-PT (Hint: use '-cpu kAFL64-Hypervisor-v1' instead)\n");
         exit(1);
     }


### PR DESCRIPTION
With the following patches, QEMU-Nyx supports now both FDL (**F**ast-**D**irty-page-**L**ogger; kAFL's/Nyx's original page tracker code from [KVM-Nyx](https://github.com/nyx-fuzz/KVM-Nyx/blob/kvm-nyx-5.10.73/arch/x86/kvm/vmx/vmx_fdl.c)) and the [dirty page ring interface](https://lwn.net/Articles/833784/) as an in-kernel page tracker in PT mode. We keep support for both modes to maintain some level of backward compatibility (before that, FDL was always required when KVM-Nyx was used).

In addition, this PR also includes two additional patches to maintain compatibility with Intel's kAFL fork. 

[Reference](https://github.com/IntelLabs/kafl.linux/issues/6#issuecomment-1450263042)