### PR TITLE
add support to configure aux buffer size via args

### DIFF
--- a/nyx/auxiliary_buffer.c
+++ b/nyx/auxiliary_buffer.c
@@ -43,6 +43,16 @@ along with QEMU-PT.  If not, see <http://www.gnu.org/licenses/>.
 #define VOLATILE_READ_16(dst, src) dst = *((volatile uint16_t *)(&src))
 #define VOLATILE_READ_8(dst, src)  dst = *((volatile uint8_t *)(&src))
 
+uint32_t misc_size(void)
+{
+    return GET_GLOBAL_STATE()->auxilary_buffer_size - (HEADER_SIZE + CAP_SIZE + CONFIG_SIZE + STATE_SIZE);
+}
+
+uint32_t misc_data_size(void)
+{
+    return misc_size() - sizeof(uint16_t);
+}
+
 static void volatile_memset(void *dst, uint8_t ch, size_t count)
 {
     for (size_t i = 0; i < count; i++) {
@@ -57,10 +67,10 @@ static void volatile_memcpy(void *dst, void *src, size_t size)
     }
 }
 
-void init_auxiliary_buffer(auxilary_buffer_t *auxilary_buffer)
+void init_auxiliary_buffer(auxilary_buffer_t *auxilary_buffer, uint32_t aux_buffer_size)
 {
     nyx_trace();
-    volatile_memset((void *)auxilary_buffer, 0, sizeof(auxilary_buffer_t));
+    volatile_memset((void *)auxilary_buffer, 0, aux_buffer_size);
 
     VOLATILE_WRITE_16(auxilary_buffer->header.version, QEMU_PT_VERSION);
 
@@ -233,9 +243,10 @@ void set_hprintf_auxiliary_buffer(auxilary_buffer_t *auxilary_buffer,
                                   char              *msg,
                                   uint32_t           len)
 {
-    VOLATILE_WRITE_16(auxilary_buffer->misc.len, MIN(len, MISC_SIZE - 2));
+    uint32_t misc_data_size_value = misc_data_size();
+    VOLATILE_WRITE_16(auxilary_buffer->misc.len, MIN(len, misc_data_size_value));
     volatile_memcpy((void *)&auxilary_buffer->misc.data, (void *)msg,
-                    (size_t)MIN(len, MISC_SIZE - 2));
+                    (size_t)MIN(len, misc_data_size_value));
     VOLATILE_WRITE_8(auxilary_buffer->result.exec_result_code, rc_hprintf);
 }
 
@@ -243,9 +254,10 @@ void set_crash_reason_auxiliary_buffer(auxilary_buffer_t *auxilary_buffer,
                                        char              *msg,
                                        uint32_t           len)
 {
-    VOLATILE_WRITE_16(auxilary_buffer->misc.len, MIN(len, MISC_SIZE - 2));
+     uint32_t misc_data_size_value = misc_data_size();
+    VOLATILE_WRITE_16(auxilary_buffer->misc.len, MIN(len, misc_data_size_value));
     volatile_memcpy((void *)&auxilary_buffer->misc.data, (void *)msg,
-                    (size_t)MIN(len, MISC_SIZE - 2));
+                    (size_t)MIN(len, misc_data_size_value));
     VOLATILE_WRITE_8(auxilary_buffer->result.exec_result_code, rc_crash);
 }
 
@@ -253,9 +265,10 @@ void set_abort_reason_auxiliary_buffer(auxilary_buffer_t *auxilary_buffer,
                                        char              *msg,
                                        uint32_t           len)
 {
-    VOLATILE_WRITE_16(auxilary_buffer->misc.len, MIN(len, MISC_SIZE - 2));
+    uint32_t misc_data_size_value = misc_data_size();
+    VOLATILE_WRITE_16(auxilary_buffer->misc.len, MIN(len, misc_data_size_value));
     volatile_memcpy((void *)&auxilary_buffer->misc.data, (void *)msg,
-                    (size_t)MIN(len, MISC_SIZE - 2));
+                    (size_t)MIN(len, misc_data_size_value));
     VOLATILE_WRITE_8(auxilary_buffer->result.exec_result_code, rc_aborted);
 }
 
@@ -295,12 +308,12 @@ void set_success_auxiliary_result_buffer(auxilary_buffer_t *auxilary_buffer,
 void set_payload_buffer_write_reason_auxiliary_buffer(
     auxilary_buffer_t *auxilary_buffer, char *msg, uint32_t len)
 {
-    VOLATILE_WRITE_16(auxilary_buffer->misc.len, MIN(len, MISC_SIZE - 2));
+    uint32_t misc_data_size_value = misc_data_size();
+    VOLATILE_WRITE_16(auxilary_buffer->misc.len, MIN(len, misc_data_size_value));
     volatile_memcpy((void *)&auxilary_buffer->misc.data, (void *)msg,
-                    (size_t)MIN(len, MISC_SIZE - 2));
+                    (size_t)MIN(len, misc_data_size_value));
     VOLATILE_WRITE_8(auxilary_buffer->result.exec_result_code, rc_input_buffer_write);
 }
-
 
 void set_tmp_snapshot_created(auxilary_buffer_t *auxilary_buffer, uint8_t value)
 {

--- a/nyx/auxiliary_buffer.h
+++ b/nyx/auxiliary_buffer.h
@@ -24,7 +24,7 @@ along with QEMU-PT.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdbool.h>
 #include <stdint.h>
 
-#define AUX_BUFFER_SIZE 4096
+#define DEFAULT_AUX_BUFFER_SIZE 4096
 
 #define AUX_MAGIC 0x54502d554d4551
 
@@ -158,7 +158,7 @@ typedef struct auxilary_buffer_s {
                             sizeof(auxilary_buffer_result_t) +\
                             sizeof(auxilary_buffer_misc_t)) % 0xFFFF)
 
-void init_auxiliary_buffer(auxilary_buffer_t *auxilary_buffer);
+void init_auxiliary_buffer(auxilary_buffer_t *auxilary_buffer, uint32_t aux_buffer_size);
 void check_auxiliary_config_buffer(auxilary_buffer_t        *auxilary_buffer,
                                    auxilary_buffer_config_t *shadow_config);
 
@@ -203,3 +203,6 @@ void set_result_bb_coverage(auxilary_buffer_t *auxilary_buffer, uint32_t value);
 
 void set_payload_buffer_write_reason_auxiliary_buffer(
     auxilary_buffer_t *auxilary_buffer, char *msg, uint32_t len);
+
+uint32_t misc_size(void);
+uint32_t misc_data_size(void);

--- a/nyx/state/state.h
+++ b/nyx/state/state.h
@@ -142,6 +142,9 @@ typedef struct qemu_nyx_state_s {
     uint64_t mem_mapping_low;
     uint64_t mem_mapping_high;
 
+    uint32_t auxilary_buffer_size;
+    char* hprintf_tmp_buffer;
+
     /* capabilites */
     uint8_t  cap_timeout_detection;
     uint8_t  cap_only_reload_mode;
@@ -187,3 +190,4 @@ void set_payload_buffer(uint64_t payload_buffer);
 void set_payload_pages(uint64_t *payload_pages, uint32_t pages);
 
 void set_workdir_path(char *workdir);
+void set_aux_buffer_size(uint32_t aux_buffer_size);


### PR DESCRIPTION
For particularly long ASAN reports it can be useful to allocate a larger aux buffer to avoid the report copied via the PANIC_EXTENDED hypercall being truncated. This PR adds this option and capability. With this patch the aux buffer can be configured via an extra parameter in the nyx device via cmd line arguments. The default value is kept to 0x1000 to maintain full compatibility with fuzzing front-ends which don't utilize this feature.

Example:
```
-device nyx,aux_buffer_size=8192 
```