### PR TITLE
add yaml serializer for snapshot meta data

### DIFF
--- a/nyx/fast_vm_reload_sync.c
+++ b/nyx/fast_vm_reload_sync.c
@@ -19,6 +19,7 @@
 #include "nyx/fast_vm_reload.h"
 #include "nyx/kvm_nested.h"
 #include "nyx/state/state.h"
+#include "nyx/state/snapshot_state.h"
 
 extern int save_snapshot(const char *name, Error **errp);
 extern int load_snapshot(const char *name, Error **errp);
@@ -138,6 +139,16 @@ static inline void create_root_snapshot(void)
         nyx_debug("===> GET_GLOBAL_STATE()->fast_reload_enabled: FALSE\n");
         /* so we haven't set a path for our snapshot files - just store everything in memory */
         fast_reload_create_in_memory(get_fast_reload_snapshot());
+
+        /* Even if we don't serialize the snapshot we still want to have the 
+         * option to export the meta data of the root snapshot as yaml file.
+         * This might be useful for the fuzzing frontend in charge; thus it 
+         * is also up to the frontend to set a path for the snapshot directory.
+         * If the path is not set, we just skip this step.
+         */ 
+        if (GET_GLOBAL_STATE()->fast_reload_path != NULL) {
+            serialize_root_snapshot_meta_data(GET_GLOBAL_STATE()->fast_reload_path);
+        }
     }
 }
 

--- a/nyx/fast_vm_reload_sync.c
+++ b/nyx/fast_vm_reload_sync.c
@@ -131,6 +131,8 @@ static inline void create_root_snapshot(void)
             fast_reload_create_in_memory(get_fast_reload_snapshot());
             fast_reload_serialize_to_file(get_fast_reload_snapshot(),
                                           GET_GLOBAL_STATE()->fast_reload_path, false);
+
+            serialize_root_snapshot_meta_data(GET_GLOBAL_STATE()->fast_reload_path);
         }
     } else {
         nyx_debug("===> GET_GLOBAL_STATE()->fast_reload_enabled: FALSE\n");

--- a/nyx/state/snapshot_state.h
+++ b/nyx/state/snapshot_state.h
@@ -44,3 +44,5 @@ typedef struct serialized_state_root_snapshot_s {
 
 void serialize_state(const char *filename_prefix, bool is_pre_snapshot);
 void deserialize_state(const char *filename_prefix);
+
+void serialize_root_snapshot_meta_data(const char *snapshot_dir);

--- a/nyx/types.h
+++ b/nyx/types.h
@@ -6,7 +6,7 @@ enum mem_mode {
     mm_32_paging,    /* 32 Bit / L3 Paging */
     mm_32_pae,       /* 32 Bit / PAE Paging */
     mm_64_l4_paging, /* 64 Bit / L4 Paging */
-    mm_64_l5_paging, /* 32 Bit / L5 Paging */
+    mm_64_l5_paging, /* 64 Bit / L5 Paging */
 };
 
 typedef uint8_t mem_mode_t;


### PR DESCRIPTION
QEMU-Nyx creates and stores several files representing the serialized root snapshot in the configured snapshot directory. With this PR, a YAML file is also created, in which specific snapshot metadata is stored in addition to the binary snapshot files. The file will not be used by QEMU-Nyx anymore after it has been created. However, the front end can easily read the YAML file without having to parse the binary file format used by QEMU-Nyx.
This PR is a WIP and lacks support for in-memory root snapshots.

Below is an example of the output YAML file:

```
---
process_trace:
    pt_ip_filter_configured_0: true
    pt_ip_filter_configured_1: false
    pt_ip_filter_configured_2: false
    pt_ip_filter_configured_3: false
    pt_ip_filter_0: [0x1000, 0xfffff000]
    pt_ip_filter_1: [0x0, 0x0]
    pt_ip_filter_2: [0x0, 0x0]
    pt_ip_filter_3: [0x0, 0x0]
    parent_cr3: 0x1fa2c000
    disassembler_word_width: 0x40
    mem_mode: 0x4
    pt_trace_mode: true

input_buffer:
    input_buffer_vaddr: 0xf7ff6000
    protect_input_buffer: false
    input_buffer_size: 0x1000

capabilites:
    cap_timeout_detection: false
    cap_only_reload_mode: false
    cap_compile_time_tracing: false
    cap_ijon_tracing: true
    cap_cr3: true
    cap_compile_time_tracing_buffer_vaddr: 0x0
    cap_ijon_tracing_buffer_vaddr: 0xf7ff8000
    cap_coverage_bitmap_size: 0x10000

...
```
