### PR TITLE
avoid unnecessary bitmap SHM resize

### DIFF
--- a/nyx/helpers.c
+++ b/nyx/helpers.c
@@ -121,6 +121,11 @@ static void resize_coverage_bitmap(uint32_t new_bitmap_size)
 {
     uint32_t new_bitmap_shm_size = new_bitmap_size;
 
+    /* check if we really need to resize the shared memory buffer */
+    if (new_bitmap_size == GET_GLOBAL_STATE()->shared_bitmap_size) {
+        return;
+    }
+
     if (new_bitmap_shm_size % 64 > 0) {
         new_bitmap_shm_size = ((new_bitmap_shm_size + 64) >> 6) << 6;
     }


### PR DESCRIPTION
If the requested SHM bitmap size is equal to the one provided by the host, don't initiate a SHM resizing. 