### PR TITLE
pass correct message length to set_abort_reason_auxiliary_buffer()

### DIFF
--- a/nyx/helpers.c
+++ b/nyx/helpers.c
@@ -28,6 +28,8 @@ void nyx_abort(const char *fmt, ...)
     msglen = vsnprintf(msg, sizeof(msg), fmt, ap);
     va_end(ap);
 
+    msglen = MIN(msglen, sizeof(msg));
+
     nyx_error("%s\n", msg);
     set_abort_reason_auxiliary_buffer(GET_GLOBAL_STATE()->auxilary_buffer, msg,
                                       msglen);


### PR DESCRIPTION
### Summary

There is an OOB read in QEMU-Nyx when a target calls the `HYPERCALL_KAFL_PANIC_EXTENDED` hypercall before the fuzzing loop is initialized with the `HYPERCALL_KAFL_ACQUIRE` hypercall. Address sanitizer outputs the following:
```
==598790==ERROR: AddressSanitizer: global-buffer-overflow on address 0x60d934988b20 at pc 0x60d932b79aea bp 0x7786a9471210 sp 0x7786a9471200                                                                                                                                                                                  
READ of size 1 at 0x60d934988b20 thread T2                                                                                                                                                                                                                                                                                    
    #0 0x60d932b79ae9 in volatile_memcpy /tmp/QEMU-Nyx/nyx/auxiliary_buffer.c:66                                                                                                                                                                                                                                              
    #1 0x60d932b7b2f4 in set_abort_reason_auxiliary_buffer /tmp/QEMU-Nyx/nyx/auxiliary_buffer.c:270                                                                                                                                                                                                                           
    #2 0x60d932b814d8 in nyx_abort /tmp/QEMU-Nyx/nyx/helpers.c:32                                                                                                                                                                                                                                                             
    #3 0x60d932bad844 in handle_hypercall_kafl_panic_extended /tmp/QEMU-Nyx/nyx/hypercall/hypercall.c:550                                                                                                                                                                                                                     
    #4 0x60d932baf5b5 in handle_kafl_hypercall /tmp/QEMU-Nyx/nyx/hypercall/hypercall.c:970                                                                                                                                                                                                                                    
    #5 0x60d932967b51 in kvm_cpu_exec /tmp/QEMU-Nyx/accel/kvm/kvm-all.c:2676                                                                                                                                                                                                                                                  
    #6 0x60d9328fa36b in qemu_kvm_cpu_thread_fn /tmp/QEMU-Nyx/cpus.c:1318                                                                                                                                                                                                                                                     
    #7 0x60d93379ee84 in qemu_thread_start util/qemu-thread-posix.c:519                                                                                                                                                                                                                                                       
    #8 0x7786c6e5d109 in asan_thread_start /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_interceptors.cpp:234                                                                                                                                                                                                                 
    #9 0x7786c56a339c  (/usr/lib/libc.so.6+0x9439c) (BuildId: 98b3d8e0b8c534c769cb871c438b4f8f3a8e4bf3)                                                                                                                                                                                                                       
    #10 0x7786c572849b  (/usr/lib/libc.so.6+0x11949b) (BuildId: 98b3d8e0b8c534c769cb871c438b4f8f3a8e4bf3)                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                              
0x60d934988b20 is located 32 bytes before global variable 'redqueen_workdir' defined in '/tmp/QEMU-Nyx/nyx/redqueen.c:38:20' (0x60d934988b40) of size 56                                                                                                                                                                      
0x60d934988b20 is located 0 bytes after global variable 'msg' defined in '/tmp/QEMU-Nyx/nyx/helpers.c:23:17' (0x60d934988920) of size 512                                                                                                                       
```

### Details:

On an extended panic call from a target we land in `handle_hypercall_kafl_panic_extended()` and call `nyx_abort()` at [nyx/hypercall/hypercall.c:550](https://github.com/nyx-fuzz/QEMU-Nyx/blob/e5e1c4c21ff9c4dc80e6409d4eab47146c6024cd/nyx/hypercall/hypercall.c#L550) with a format string and a temporary hprintf buffer as parameters. `nyx_abort()` builds a message out of them with `vsnprintf()` at [nyx/helpers.c:28](https://github.com/nyx-fuzz/QEMU-Nyx/blob/e5e1c4c21ff9c4dc80e6409d4eab47146c6024cd/nyx/helpers.c#L28). The problem is that `msglen` returned from `vsnprintf()`  might be larger than the written message `msg`, as `vsnprintf()` might return the bytes needed. In `set_abort_reason_auxiliary_buffer()` this length is used for memcpy at [nyx/auxiliary_buffer.c:271](https://github.com/nyx-fuzz/QEMU-Nyx/blob/e5e1c4c21ff9c4dc80e6409d4eab47146c6024cd/nyx/auxiliary_buffer.c#L271) which reads past the end of the 512-bytes fixed-sized `msg` buffer.

### Possible Fix:

Instead of passing `msglen` to `set_abort_reason_auxiliary_buffer()`,  pass at most the length of `msg` (512) or less to it.
In practice a fix is not strictly required as calling "extended panic" before "acquire" always terminates QEMU anyway. It is still cleaner this way.

